### PR TITLE
Fixed url parameters in the DSL yml files

### DIFF
--- a/DSL/Ruuter/GET/active-services.yml
+++ b/DSL/Ruuter/GET/active-services.yml
@@ -1,7 +1,7 @@
 get_services_list:
   call: http.post
   args:
-    url: http://resql:8087/get-active-services-list
+    url: "[#SERVICE_RESQL]/get-active-services-list"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/active-services.yml
+++ b/DSL/Ruuter/GET/active-services.yml
@@ -1,7 +1,7 @@
 get_services_list:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-active-services-list"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/get-active-services-list"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/active-services.yml
+++ b/DSL/Ruuter/GET/active-services.yml
@@ -1,7 +1,7 @@
 get_services_list:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/get-active-services-list"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-active-services-list"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/domain-file.yml
+++ b/DSL/Ruuter/GET/domain-file.yml
@@ -7,7 +7,7 @@ getFileLocations:
 getDomainFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/read
+    url: "[#SERVICE_NODE]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
   result: domainFile
@@ -15,7 +15,7 @@ getDomainFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/yaml_to_json
+    url: "[#SERVICE_NODE]/conversion/yaml_to_json"
     body:
       file: ${domainFile.response.body.file}
   result: domainData

--- a/DSL/Ruuter/GET/domain-file.yml
+++ b/DSL/Ruuter/GET/domain-file.yml
@@ -7,7 +7,7 @@ getFileLocations:
 getDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/read"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
   result: domainFile
@@ -15,7 +15,7 @@ getDomainFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/yaml_to_json"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/yaml_to_json"
     body:
       file: ${domainFile.response.body.file}
   result: domainData

--- a/DSL/Ruuter/GET/domain-file.yml
+++ b/DSL/Ruuter/GET/domain-file.yml
@@ -7,7 +7,7 @@ getFileLocations:
 getDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/read"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
   result: domainFile
@@ -15,7 +15,7 @@ getDomainFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/yaml_to_json"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/yaml_to_json"
     body:
       file: ${domainFile.response.body.file}
   result: domainData

--- a/DSL/Ruuter/GET/entities.yml
+++ b/DSL/Ruuter/GET/entities.yml
@@ -1,13 +1,13 @@
 getEntities:
   call: http.get
   args:
-    url: http://opensearch:9200/entities/_search?size=10000
+    url: "[#SERVICE_OPENSEARCH]/entities/_search?size=10000"
   result: getEntitiesResult
   
 mapEntitiesData:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-entities
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-entities"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/entities.yml
+++ b/DSL/Ruuter/GET/entities.yml
@@ -1,13 +1,13 @@
 getEntities:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]/entities/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/entities/_search?size=10000"
   result: getEntitiesResult
   
 mapEntitiesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-entities"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-entities"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/entities.yml
+++ b/DSL/Ruuter/GET/entities.yml
@@ -1,13 +1,13 @@
 getEntities:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/entities/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/entities/_search?size=10000"
   result: getEntitiesResult
   
 mapEntitiesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-entities"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-entities"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/get-sticky.yml
+++ b/DSL/Ruuter/GET/get-sticky.yml
@@ -7,7 +7,7 @@ check_for_parameters:
 get_single_sticky_service:
   call: http.post
   args:
-    url: http://node_server:3008/ruuter/sticky/steps
+    url: "[#SERVICE_NODE]/ruuter/sticky/steps"
     query:
       name: ${incoming.params.name}
   result: results
@@ -16,7 +16,7 @@ get_single_sticky_service:
 get_all_sticky_services:
   call: http.get
   args:
-    url: http://node_server:3008/ruuter/sticky
+    url: "[#SERVICE_NODE]/ruuter/sticky"
   result: results
   next: return_ok
 

--- a/DSL/Ruuter/GET/get-sticky.yml
+++ b/DSL/Ruuter/GET/get-sticky.yml
@@ -7,7 +7,7 @@ check_for_parameters:
 get_single_sticky_service:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/ruuter/sticky/steps"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/ruuter/sticky/steps"
     query:
       name: ${incoming.params.name}
   result: results
@@ -16,7 +16,7 @@ get_single_sticky_service:
 get_all_sticky_services:
   call: http.get
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/ruuter/sticky"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/ruuter/sticky"
   result: results
   next: return_ok
 

--- a/DSL/Ruuter/GET/get-sticky.yml
+++ b/DSL/Ruuter/GET/get-sticky.yml
@@ -7,7 +7,7 @@ check_for_parameters:
 get_single_sticky_service:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/ruuter/sticky/steps"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/ruuter/sticky/steps"
     query:
       name: ${incoming.params.name}
   result: results
@@ -16,7 +16,7 @@ get_single_sticky_service:
 get_all_sticky_services:
   call: http.get
   args:
-    url: "[#SERVICE_NODE]/ruuter/sticky"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/ruuter/sticky"
   result: results
   next: return_ok
 

--- a/DSL/Ruuter/GET/intents.yml
+++ b/DSL/Ruuter/GET/intents.yml
@@ -1,13 +1,13 @@
 getIntents:
   call: http.get
   args:
-    url: http://opensearch:9200/intents/_search?size=10000
+    url: "[#SERVICE_OPENSEARCH]/intents/_search?size=10000"
   result: getIntentsResult
 
 mapIntentsData:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-intents
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-intents"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/intents.yml
+++ b/DSL/Ruuter/GET/intents.yml
@@ -1,13 +1,13 @@
 getIntents:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]/intents/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/intents/_search?size=10000"
   result: getIntentsResult
 
 mapIntentsData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-intents"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-intents"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/intents.yml
+++ b/DSL/Ruuter/GET/intents.yml
@@ -1,13 +1,13 @@
 getIntents:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/intents/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/intents/_search?size=10000"
   result: getIntentsResult
 
 mapIntentsData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-intents"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-intents"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/overview/services-detailed/nok.yml
+++ b/DSL/Ruuter/GET/overview/services-detailed/nok.yml
@@ -1,13 +1,13 @@
 getFaults:
   call: http.get
   args:
-    url: http://opensearch:9200/faults/_search?size=10000
+    url: "[#SERVICE_OPENSEARCH]/faults/_search?size=10000"
   result: getFaultsResult
 
 mapFaultsData:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-faults
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-faults"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/overview/services-detailed/nok.yml
+++ b/DSL/Ruuter/GET/overview/services-detailed/nok.yml
@@ -1,13 +1,13 @@
 getFaults:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]/faults/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/faults/_search?size=10000"
   result: getFaultsResult
 
 mapFaultsData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-faults"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-faults"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/overview/services-detailed/nok.yml
+++ b/DSL/Ruuter/GET/overview/services-detailed/nok.yml
@@ -1,13 +1,13 @@
 getFaults:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/faults/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/faults/_search?size=10000"
   result: getFaultsResult
 
 mapFaultsData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-faults"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-faults"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/GET/regex.yml
+++ b/DSL/Ruuter/GET/regex.yml
@@ -1,13 +1,13 @@
 getRegexes:
   call: http.get
   args:
-    url: http://opensearch:9200/regexes/_search?size=10000
+    url: "[#SERVICE_OPENSEARCH]/regexes/_search?size=10000"
   result: getRegexesResult
 
 mapRegexesData:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-regexes
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-regexes"
     headers:
       type: "json"
     body:

--- a/DSL/Ruuter/GET/regex.yml
+++ b/DSL/Ruuter/GET/regex.yml
@@ -1,13 +1,13 @@
 getRegexes:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]/regexes/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/regexes/_search?size=10000"
   result: getRegexesResult
 
 mapRegexesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-regexes"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-regexes"
     headers:
       type: "json"
     body:

--- a/DSL/Ruuter/GET/regex.yml
+++ b/DSL/Ruuter/GET/regex.yml
@@ -1,13 +1,13 @@
 getRegexes:
   call: http.get
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/regexes/_search?size=10000"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/regexes/_search?size=10000"
   result: getRegexesResult
 
 mapRegexesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-regexes"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-regexes"
     headers:
       type: "json"
     body:

--- a/DSL/Ruuter/GET/secrets-with-priority.yml
+++ b/DSL/Ruuter/GET/secrets-with-priority.yml
@@ -7,14 +7,14 @@ check_parameters:
 get_ruuter_secrets_prod_priority:
   call: http.post
   args:
-    url: http://data_mapper:3005/secrets/get-with-priority
+    url: "[#SERVICE_DMAPPER]/secrets/get-with-priority"
   result: results
   next: return_ok
 
 get_ruuter_secrets_test_priority:
   call: http.post
   args:
-    url: http://data_mapper:3005/secrets/get-with-priority?priority=test
+    url: "[#SERVICE_DMAPPER]/secrets/get-with-priority?priority=test"
   result: results
   next: return_ok
 

--- a/DSL/Ruuter/GET/secrets-with-priority.yml
+++ b/DSL/Ruuter/GET/secrets-with-priority.yml
@@ -7,14 +7,14 @@ check_parameters:
 get_ruuter_secrets_prod_priority:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/secrets/get-with-priority"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/secrets/get-with-priority"
   result: results
   next: return_ok
 
 get_ruuter_secrets_test_priority:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/secrets/get-with-priority?priority=test"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/secrets/get-with-priority?priority=test"
   result: results
   next: return_ok
 

--- a/DSL/Ruuter/GET/secrets-with-priority.yml
+++ b/DSL/Ruuter/GET/secrets-with-priority.yml
@@ -7,14 +7,14 @@ check_parameters:
 get_ruuter_secrets_prod_priority:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/secrets/get-with-priority"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/secrets/get-with-priority"
   result: results
   next: return_ok
 
 get_ruuter_secrets_test_priority:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/secrets/get-with-priority?priority=test"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/secrets/get-with-priority?priority=test"
   result: results
   next: return_ok
 

--- a/DSL/Ruuter/GET/secrets.yml
+++ b/DSL/Ruuter/GET/secrets.yml
@@ -1,7 +1,7 @@
 get_ruuter_secrets:
   call: http.post
   args:
-    url: http://data_mapper:3005/secrets/get-all
+    url: "[#SERVICE_DMAPPER]/secrets/get-all"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/secrets.yml
+++ b/DSL/Ruuter/GET/secrets.yml
@@ -1,7 +1,7 @@
 get_ruuter_secrets:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/secrets/get-all"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/secrets/get-all"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/secrets.yml
+++ b/DSL/Ruuter/GET/secrets.yml
@@ -1,7 +1,7 @@
 get_ruuter_secrets:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/secrets/get-all"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/secrets/get-all"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/service-settings.yml
+++ b/DSL/Ruuter/GET/service-settings.yml
@@ -1,7 +1,7 @@
 updateSettings:
   call: http.post
   args:
-    url: http://resql:8087/get-settings
+    url: "[#SERVICE_RESQL]/get-settings"
   result: results
 
 returnSuccess:

--- a/DSL/Ruuter/GET/service-settings.yml
+++ b/DSL/Ruuter/GET/service-settings.yml
@@ -1,7 +1,7 @@
 updateSettings:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/get-settings"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-settings"
   result: results
 
 returnSuccess:

--- a/DSL/Ruuter/GET/service-settings.yml
+++ b/DSL/Ruuter/GET/service-settings.yml
@@ -1,7 +1,7 @@
 updateSettings:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-settings"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/get-settings"
   result: results
 
 returnSuccess:

--- a/DSL/Ruuter/GET/services.yml
+++ b/DSL/Ruuter/GET/services.yml
@@ -1,7 +1,7 @@
 get_services_list:
   call: http.post
   args:
-    url: http://resql:8087/get-services-list
+    url: "[#SERVICE_RESQL]/get-services-list"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/services.yml
+++ b/DSL/Ruuter/GET/services.yml
@@ -1,7 +1,7 @@
 get_services_list:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/get-services-list"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-services-list"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/services.yml
+++ b/DSL/Ruuter/GET/services.yml
@@ -1,7 +1,7 @@
 get_services_list:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-services-list"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/get-services-list"
   result: results
 
 return_ok:

--- a/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-prod-info.yml
+++ b/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-prod-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.get
   args:
-    url: http://localhost:8085/services/endpoints/configs/service-endpoint-prod-configs
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-prod-info.yml
+++ b/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-prod-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-prod-info.yml
+++ b/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-prod-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/configs/service-endpoint-prod-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-test-info.yml
+++ b/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-test-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.get
   args:
-    url: http://localhost:8085/services/endpoints/configs/service-endpoint-test-configs
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-test-info.yml
+++ b/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-test-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-test-info.yml
+++ b/DSL/Ruuter/GET/services/endpoints/info/service-endpoint-test-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/configs/service-endpoint-test-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/GET/services/endpoints/service-endpoint.yml
+++ b/DSL/Ruuter/GET/services/endpoints/service-endpoint.yml
@@ -18,14 +18,14 @@ check_for_environment:
 get_prod_info:
   call: http.get
   args:
-    url: http://localhost:8085/services/endpoints/info/service-endpoint-prod-info
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
   result: info
   next: check_for_endpoint_url
  
 get_test_info:
   call: http.get
   args:
-    url: http://localhost:8085/services/endpoints/info/service-endpoint-test-info
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
   result: info 
   next: check_for_endpoint_url
 

--- a/DSL/Ruuter/GET/services/endpoints/service-endpoint.yml
+++ b/DSL/Ruuter/GET/services/endpoints/service-endpoint.yml
@@ -18,14 +18,14 @@ check_for_environment:
 get_prod_info:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
   result: info
   next: check_for_endpoint_url
  
 get_test_info:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
   result: info 
   next: check_for_endpoint_url
 

--- a/DSL/Ruuter/GET/services/endpoints/service-endpoint.yml
+++ b/DSL/Ruuter/GET/services/endpoints/service-endpoint.yml
@@ -18,14 +18,14 @@ check_for_environment:
 get_prod_info:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/info/service-endpoint-prod-info"
   result: info
   next: check_for_endpoint_url
  
 get_test_info:
   call: http.get
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/info/service-endpoint-test-info"
   result: info 
   next: check_for_endpoint_url
 

--- a/DSL/Ruuter/GET/services/log-by-request.yml
+++ b/DSL/Ruuter/GET/services/log-by-request.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: http://opensearch:9200/services/_search/template
+    url: "[#SERVICE_OPENSEARCH]/services/_search/template"
     body:
       id: 'get-log-by-request'
       params: ${incoming.params}

--- a/DSL/Ruuter/GET/services/log-by-request.yml
+++ b/DSL/Ruuter/GET/services/log-by-request.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/services/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/services/_search/template"
     body:
       id: 'get-log-by-request'
       params: ${incoming.params}

--- a/DSL/Ruuter/GET/services/log-by-request.yml
+++ b/DSL/Ruuter/GET/services/log-by-request.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]/services/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/services/_search/template"
     body:
       id: 'get-log-by-request'
       params: ${incoming.params}

--- a/DSL/Ruuter/GET/services/log-by-service.yml
+++ b/DSL/Ruuter/GET/services/log-by-service.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: http://opensearch:9200/services/_search/template
+    url: "[#SERVICE_OPENSEARCH]/services/_search/template"
     body:
       id: 'get-log-by-service'
       params: ${incoming.params}

--- a/DSL/Ruuter/GET/services/log-by-service.yml
+++ b/DSL/Ruuter/GET/services/log-by-service.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/services/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/services/_search/template"
     body:
       id: 'get-log-by-service'
       params: ${incoming.params}

--- a/DSL/Ruuter/GET/services/log-by-service.yml
+++ b/DSL/Ruuter/GET/services/log-by-service.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]/services/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/services/_search/template"
     body:
       id: 'get-log-by-service'
       params: ${incoming.params}

--- a/DSL/Ruuter/GET/services/statistics.yml
+++ b/DSL/Ruuter/GET/services/statistics.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: http://opensearch:9200/services/_search/template
+    url: "[#SERVICE_OPENSEARCH]/services/_search/template"
     body:
       id: 'get-services-stat'
   result: results

--- a/DSL/Ruuter/GET/services/statistics.yml
+++ b/DSL/Ruuter/GET/services/statistics.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]/services/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/services/_search/template"
     body:
       id: 'get-services-stat'
   result: results

--- a/DSL/Ruuter/GET/services/statistics.yml
+++ b/DSL/Ruuter/GET/services/statistics.yml
@@ -1,7 +1,7 @@
 get_services_stat:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/services/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/services/_search/template"
     body:
       id: 'get-services-stat'
   result: results

--- a/DSL/Ruuter/GET/services/status.yml
+++ b/DSL/Ruuter/GET/services/status.yml
@@ -1,7 +1,7 @@
 get_status:
   call: http.post
   args:
-    url: http://resql:8087/status
+    url: "[#SERVICE_RESQL]/status"
     body:
       id: ${incoming.body.id}
   result: res

--- a/DSL/Ruuter/GET/services/status.yml
+++ b/DSL/Ruuter/GET/services/status.yml
@@ -1,7 +1,7 @@
 get_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/status"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/status"
     body:
       id: ${incoming.body.id}
   result: res

--- a/DSL/Ruuter/GET/services/status.yml
+++ b/DSL/Ruuter/GET/services/status.yml
@@ -1,7 +1,7 @@
 get_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/status"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/status"
     body:
       id: ${incoming.body.id}
   result: res

--- a/DSL/Ruuter/GET/sticky/example2.yml
+++ b/DSL/Ruuter/GET/sticky/example2.yml
@@ -11,7 +11,7 @@ extract_request_data:
 extract_cookie_data:
   call: http.post
   args:
-    url: http://ruuter:8080/mocks/mock-custom-jwt-userinfo
+    url: "[#SERVICE_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:

--- a/DSL/Ruuter/GET/sticky/example2.yml
+++ b/DSL/Ruuter/GET/sticky/example2.yml
@@ -11,7 +11,7 @@ extract_request_data:
 extract_cookie_data:
   call: http.post
   args:
-    url: "[#SERVICE_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo"
+    url: "[#SERVICE_PUBLIC_RUUTER]:[#PORT_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:

--- a/DSL/Ruuter/GET/sticky/example2.yml
+++ b/DSL/Ruuter/GET/sticky/example2.yml
@@ -11,7 +11,7 @@ extract_request_data:
 extract_cookie_data:
   call: http.post
   args:
-    url: "[#SERVICE_PUBLIC_RUUTER]:[#PORT_PUBLIC_RUUTER]/mocks/mock-custom-jwt-userinfo"
+    url: "[#SERVICE_PUBLIC_RUUTER]:[#SERVICE_PUBLIC_RUUTER_PORT]/mocks/mock-custom-jwt-userinfo"
     headers:
       cookie: ${cookie}
     body:

--- a/DSL/Ruuter/POST/csv.yml
+++ b/DSL/Ruuter/POST/csv.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 get_csv:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-csv
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-csv"
     headers:
       type: 'csv'
     body:

--- a/DSL/Ruuter/POST/csv.yml
+++ b/DSL/Ruuter/POST/csv.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 get_csv:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-csv"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-csv"
     headers:
       type: 'csv'
     body:

--- a/DSL/Ruuter/POST/csv.yml
+++ b/DSL/Ruuter/POST/csv.yml
@@ -7,7 +7,7 @@ check_for_required_parameters:
 get_csv:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-csv"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-csv"
     headers:
       type: 'csv'
     body:

--- a/DSL/Ruuter/POST/dates/calculate-difference.yml
+++ b/DSL/Ruuter/POST/dates/calculate-difference.yml
@@ -29,7 +29,7 @@ check_is_output_type_valid:
 calculate_difference:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/calculate-date-difference
+    url: "[#SERVICE_DMAPPER]/hbs/services/calculate-date-difference"
     headers:
       type: "json"
     body:

--- a/DSL/Ruuter/POST/dates/calculate-difference.yml
+++ b/DSL/Ruuter/POST/dates/calculate-difference.yml
@@ -29,7 +29,7 @@ check_is_output_type_valid:
 calculate_difference:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/calculate-date-difference"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/calculate-date-difference"
     headers:
       type: "json"
     body:

--- a/DSL/Ruuter/POST/dates/calculate-difference.yml
+++ b/DSL/Ruuter/POST/dates/calculate-difference.yml
@@ -29,7 +29,7 @@ check_is_output_type_valid:
 calculate_difference:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/calculate-date-difference"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/calculate-date-difference"
     headers:
       type: "json"
     body:

--- a/DSL/Ruuter/POST/entities.yml
+++ b/DSL/Ruuter/POST/entities.yml
@@ -5,7 +5,7 @@ assign_values:
 getEntitiesWithName:
   call: http.post
   args:
-    url: http://opensearch:9200/entities/_search/template
+    url: "[#SERVICE_OPENSEARCH]/entities/_search/template"
     body:
       id: "entity-with-name"
       params: ${params}
@@ -14,7 +14,7 @@ getEntitiesWithName:
 mapEntitiesData:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-entity-with-name
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-entity-with-name"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/entities.yml
+++ b/DSL/Ruuter/POST/entities.yml
@@ -5,7 +5,7 @@ assign_values:
 getEntitiesWithName:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/entities/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/entities/_search/template"
     body:
       id: "entity-with-name"
       params: ${params}
@@ -14,7 +14,7 @@ getEntitiesWithName:
 mapEntitiesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-entity-with-name"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-entity-with-name"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/entities.yml
+++ b/DSL/Ruuter/POST/entities.yml
@@ -5,7 +5,7 @@ assign_values:
 getEntitiesWithName:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]/entities/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/entities/_search/template"
     body:
       id: "entity-with-name"
       params: ${params}
@@ -14,7 +14,7 @@ getEntitiesWithName:
 mapEntitiesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-entity-with-name"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-entity-with-name"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/file/rename.yml
+++ b/DSL/Ruuter/POST/file/rename.yml
@@ -6,7 +6,7 @@ check_for_body:
 rename_file:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/rename
+    url: "[#DMAPPER]/hbs/services/rename"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/file/rename.yml
+++ b/DSL/Ruuter/POST/file/rename.yml
@@ -6,7 +6,7 @@ check_for_body:
 rename_file:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/rename"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/rename"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/file/rename.yml
+++ b/DSL/Ruuter/POST/file/rename.yml
@@ -6,7 +6,7 @@ check_for_body:
 rename_file:
   call: http.post
   args:
-    url: "[#DMAPPER]/hbs/services/rename"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/rename"
     headers:
       type: 'json'
     body:

--- a/DSL/Ruuter/POST/rasa/entities/add.yml
+++ b/DSL/Ruuter/POST/rasa/entities/add.yml
@@ -17,7 +17,7 @@ validateEntities:
 mergeEntities:
   call: http.post
   args:
-    url: http://node_server:3008/file/merge
+    url: "[#SERVICE_NODE]/file/merge"
     body:
       array1: ${domainData.response.body.response.entities}
       array2: ${[parameters.entity]}
@@ -26,7 +26,7 @@ mergeEntities:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/json_to_yaml
+    url: "[#SERVICE_NODE]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -47,7 +47,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#SERVICE_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/add.yml
+++ b/DSL/Ruuter/POST/rasa/entities/add.yml
@@ -17,7 +17,7 @@ validateEntities:
 mergeEntities:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/merge"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/merge"
     body:
       array1: ${domainData.response.body.response.entities}
       array2: ${[parameters.entity]}
@@ -26,7 +26,7 @@ mergeEntities:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/json_to_yaml"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -47,7 +47,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/add.yml
+++ b/DSL/Ruuter/POST/rasa/entities/add.yml
@@ -17,7 +17,7 @@ validateEntities:
 mergeEntities:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/merge"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/merge"
     body:
       array1: ${domainData.response.body.response.entities}
       array2: ${[parameters.entity]}
@@ -26,7 +26,7 @@ mergeEntities:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -47,7 +47,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/delete.yml
+++ b/DSL/Ruuter/POST/rasa/entities/delete.yml
@@ -72,7 +72,7 @@ deleteEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/json_to_yaml
+    url: "[#SERVICE_NODE]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -93,7 +93,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#SERVICE_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/delete.yml
+++ b/DSL/Ruuter/POST/rasa/entities/delete.yml
@@ -72,7 +72,7 @@ deleteEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/json_to_yaml"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -93,7 +93,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/delete.yml
+++ b/DSL/Ruuter/POST/rasa/entities/delete.yml
@@ -72,7 +72,7 @@ deleteEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -93,7 +93,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter/POST/rasa/entities/update.yml
@@ -27,7 +27,7 @@ replaceExistingEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/json_to_yaml
+    url: "[#SERVICE_NODE]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -48,7 +48,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#SERVICE_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}
@@ -63,7 +63,7 @@ switchFileType:
 getRegexFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/read
+    url: "[#SERVICE_NODE]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: intentFile
@@ -72,7 +72,7 @@ getRegexFile:
 getIntentFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/read
+    url: "[#SERVICE_NODE]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
   result: intentFile
@@ -80,7 +80,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/yaml-to-json
+    url: "[#SERVICE_NODE]/conversion/yaml-to-json"
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -132,7 +132,7 @@ mapIntentsData:
 convertIntentJsonToYaml:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/json-to-yaml
+    url: "[#NODE]/conversion/json-to-yaml"
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -147,7 +147,7 @@ switchSaveFileType:
 saveRegexFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
       content: ${intentYaml.response.body.json}
@@ -157,7 +157,7 @@ saveRegexFile:
 saveIntentFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter/POST/rasa/entities/update.yml
@@ -27,7 +27,7 @@ replaceExistingEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/json_to_yaml"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -48,7 +48,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}
@@ -63,7 +63,7 @@ switchFileType:
 getRegexFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/read"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: intentFile
@@ -72,7 +72,7 @@ getRegexFile:
 getIntentFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/read"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
   result: intentFile
@@ -80,7 +80,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/yaml-to-json"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/yaml-to-json"
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -132,7 +132,7 @@ mapIntentsData:
 convertIntentJsonToYaml:
   call: http.post
   args:
-    url: "[#NODE]/conversion/json-to-yaml"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json-to-yaml"
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -147,7 +147,7 @@ switchSaveFileType:
 saveRegexFile:
   call: http.post
   args:
-    url: "[#NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
       content: ${intentYaml.response.body.json}
@@ -157,7 +157,7 @@ saveRegexFile:
 saveIntentFile:
   call: http.post
   args:
-    url: "[#NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter/POST/rasa/entities/update.yml
+++ b/DSL/Ruuter/POST/rasa/entities/update.yml
@@ -27,7 +27,7 @@ replaceExistingEntity:
 convertJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/json_to_yaml"
     body:
       version: ${domainData.response.body.response.version}
       intents: ${domainData.response.body.response.intents}
@@ -48,7 +48,7 @@ getFileLocations:
 saveDomainFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.domain_location}
       content: ${domainYaml.response.body.json}
@@ -63,7 +63,7 @@ switchFileType:
 getRegexFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/read"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
   result: intentFile
@@ -72,7 +72,7 @@ getRegexFile:
 getIntentFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/read"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/read"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
   result: intentFile
@@ -80,7 +80,7 @@ getIntentFile:
 convertYamlToJson:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/yaml-to-json"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/yaml-to-json"
     body:
       file: ${intentFile.response.body.file}
   result: intentData
@@ -132,7 +132,7 @@ mapIntentsData:
 convertIntentJsonToYaml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json-to-yaml"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/json-to-yaml"
     body:
       version: "3.0"
       nlu: ${intentFileJson.response.body}
@@ -147,7 +147,7 @@ switchSaveFileType:
 saveRegexFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.regex_location}
       content: ${intentYaml.response.body.json}
@@ -157,7 +157,7 @@ saveRegexFile:
 saveIntentFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
       content: ${intentYaml.response.body.json}

--- a/DSL/Ruuter/POST/regex.yml
+++ b/DSL/Ruuter/POST/regex.yml
@@ -5,7 +5,7 @@ assign_values:
 getRegexesWithName:
   call: http.post
   args:
-    url: http://opensearch:9200/regexes/_search/template
+    url: "[#SERVICE_OPENSEARCH]/regexes/_search/template"
     body:
       id: "regex-with-name"
       params: ${params}
@@ -15,7 +15,7 @@ getRegexesWithName:
 mapRegexesData:
   call: http.post
   args:
-    url: http://data_mapper:3005/hbs/services/get-regex-with-name
+    url: "[#SERVICE_DMAPPER]/hbs/services/get-regex-with-name"
     body:
       hits: ${getRegexesResult.response.body.hits.hits}
       examples: ${params.examples}

--- a/DSL/Ruuter/POST/regex.yml
+++ b/DSL/Ruuter/POST/regex.yml
@@ -5,7 +5,7 @@ assign_values:
 getRegexesWithName:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/regexes/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/regexes/_search/template"
     body:
       id: "regex-with-name"
       params: ${params}
@@ -15,7 +15,7 @@ getRegexesWithName:
 mapRegexesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-regex-with-name"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/hbs/services/get-regex-with-name"
     body:
       hits: ${getRegexesResult.response.body.hits.hits}
       examples: ${params.examples}

--- a/DSL/Ruuter/POST/regex.yml
+++ b/DSL/Ruuter/POST/regex.yml
@@ -5,7 +5,7 @@ assign_values:
 getRegexesWithName:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]/regexes/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/regexes/_search/template"
     body:
       id: "regex-with-name"
       params: ${params}
@@ -15,7 +15,7 @@ getRegexesWithName:
 mapRegexesData:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]/hbs/services/get-regex-with-name"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/hbs/services/get-regex-with-name"
     body:
       hits: ${getRegexesResult.response.body.hits.hits}
       examples: ${params.examples}

--- a/DSL/Ruuter/POST/saveJsonToYml.yml
+++ b/DSL/Ruuter/POST/saveJsonToYml.yml
@@ -1,7 +1,7 @@
 toYml:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/json_to_yaml_data
+    url: "[#SERVICE_NODE]/conversion/json_to_yaml_data"
     body:
       data: ${incoming.body.result}
   result: r
@@ -9,7 +9,7 @@ toYml:
 saveFile:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#SERVICE_NODE]/file/write"
     body:
       file_path: ${incoming.params.location}
       content: ${r.response.body.yaml}

--- a/DSL/Ruuter/POST/saveJsonToYml.yml
+++ b/DSL/Ruuter/POST/saveJsonToYml.yml
@@ -1,7 +1,7 @@
 toYml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/json_to_yaml_data"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml_data"
     body:
       data: ${incoming.body.result}
   result: r
@@ -9,7 +9,7 @@ toYml:
 saveFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: ${incoming.params.location}
       content: ${r.response.body.yaml}

--- a/DSL/Ruuter/POST/saveJsonToYml.yml
+++ b/DSL/Ruuter/POST/saveJsonToYml.yml
@@ -1,7 +1,7 @@
 toYml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml_data"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/json_to_yaml_data"
     body:
       data: ${incoming.body.result}
   result: r
@@ -9,7 +9,7 @@ toYml:
 saveFile:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: ${incoming.params.location}
       content: ${r.response.body.yaml}

--- a/DSL/Ruuter/POST/service-settings.yml
+++ b/DSL/Ruuter/POST/service-settings.yml
@@ -1,7 +1,7 @@
 updateSettings:
   call: http.post
   args:
-    url: http://resql:8087/update-settings
+    url: "[#SERVICE_RESQL]/update-settings"
     body:
       name: ${incoming.body.name}
       value: ${incoming.body.value}

--- a/DSL/Ruuter/POST/service-settings.yml
+++ b/DSL/Ruuter/POST/service-settings.yml
@@ -1,7 +1,7 @@
 updateSettings:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/update-settings"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/update-settings"
     body:
       name: ${incoming.body.name}
       value: ${incoming.body.value}

--- a/DSL/Ruuter/POST/service-settings.yml
+++ b/DSL/Ruuter/POST/service-settings.yml
@@ -1,7 +1,7 @@
 updateSettings:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/update-settings"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/update-settings"
     body:
       name: ${incoming.body.name}
       value: ${incoming.body.value}

--- a/DSL/Ruuter/POST/services/add.yml
+++ b/DSL/Ruuter/POST/services/add.yml
@@ -15,7 +15,7 @@ extract_request_data:
 service_add:
   call: http.post
   args:
-    url: http://resql:8087/add
+    url: "[#SERVICE_RESQL]/add"
     body:
       name: ${name}
       description: ${description}
@@ -25,7 +25,7 @@ service_add:
 convert_json_content_to_yml:
   call: http.post
   args:
-    url: http://node_server:3008/conversion/json_to_yaml_data
+    url: "[#SERVICE_NODE]/conversion/json_to_yaml_data"
     body:
       data: ${content}
   result: ymlResult
@@ -39,7 +39,7 @@ check_for_type:
 add_get_dsl:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#SERVICE_NODE]/file/write"
     body:
       file_path: "/Ruuter/GET/services/draft/${name}.tmp"
       content: ${ymlResult.response.body.yaml}
@@ -49,7 +49,7 @@ add_get_dsl:
 add_post_dsl:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#SERVICE_NODE]/file/write"
     body:
       file_path: "/Ruuter/POST/services/draft/${name}.tmp"
       content: ${ymlResult.response.body.yaml}

--- a/DSL/Ruuter/POST/services/add.yml
+++ b/DSL/Ruuter/POST/services/add.yml
@@ -15,7 +15,7 @@ extract_request_data:
 service_add:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/add"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/add"
     body:
       name: ${name}
       description: ${description}
@@ -25,7 +25,7 @@ service_add:
 convert_json_content_to_yml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/conversion/json_to_yaml_data"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml_data"
     body:
       data: ${content}
   result: ymlResult
@@ -39,7 +39,7 @@ check_for_type:
 add_get_dsl:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: "/Ruuter/GET/services/draft/${name}.tmp"
       content: ${ymlResult.response.body.yaml}
@@ -49,7 +49,7 @@ add_get_dsl:
 add_post_dsl:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: "/Ruuter/POST/services/draft/${name}.tmp"
       content: ${ymlResult.response.body.yaml}

--- a/DSL/Ruuter/POST/services/add.yml
+++ b/DSL/Ruuter/POST/services/add.yml
@@ -15,7 +15,7 @@ extract_request_data:
 service_add:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/add"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/add"
     body:
       name: ${name}
       description: ${description}
@@ -25,7 +25,7 @@ service_add:
 convert_json_content_to_yml:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/conversion/json_to_yaml_data"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/conversion/json_to_yaml_data"
     body:
       data: ${content}
   result: ymlResult
@@ -39,7 +39,7 @@ check_for_type:
 add_get_dsl:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: "/Ruuter/GET/services/draft/${name}.tmp"
       content: ${ymlResult.response.body.yaml}
@@ -49,7 +49,7 @@ add_get_dsl:
 add_post_dsl:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: "/Ruuter/POST/services/draft/${name}.tmp"
       content: ${ymlResult.response.body.yaml}

--- a/DSL/Ruuter/POST/services/delete.yml
+++ b/DSL/Ruuter/POST/services/delete.yml
@@ -13,7 +13,7 @@ extract_request_data:
 get_status_name:
   call: http.post
   args:
-    url: http://resql:8087/get-service-name-by-id
+    url: "[#SERVICE_RESQL]/get-service-name-by-id"
     body:
       id: ${id}
   result: name_res
@@ -22,7 +22,7 @@ get_status_name:
 get_current_status:
   call: http.post
   args:
-    url: http://resql:8087/status
+    url: "[#SERVICE_RESQL]/status"
     body:
       id: ${id}
   result: status_res
@@ -42,7 +42,7 @@ assign_old_path:
 delete_service:
   call: http.post
   args:
-    url: http://resql:8087/delete-service
+    url: "[#SERVICE_RESQL]/delete-service"
     body:
       id: ${id}
   result: res
@@ -51,7 +51,7 @@ delete_service:
 check_service_file_exists:
   call: http.post
   args:
-    url: http://node_server:3008/file/check
+    url: "[#SERVICE_NODE]/file/check"
     body:
       file_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name_res.response.body[0].name}.tmp"
   result: service_file_exists
@@ -66,7 +66,7 @@ validate_service_file_exists:
 delete_deactivated_service:
   call: http.post
   args:
-    url: http://node_server:3008/file/delete
+    url: "[#SERVICE_NODE]/file/delete"
     body:
       path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name_res.response.body[0].name}.tmp"
   result: results
@@ -92,7 +92,7 @@ delete_response:
 check_intent_file_exists:
   call: http.post
   args:
-    url: http://node_server:3008/file/check
+    url: "[#NODE]/file/check"
     body:
       file_path: "/mock1/data/nlu/removed/service_${name_res.response.body[0].name}_nlu.tmp"
   result: intent_file_exists_result
@@ -107,7 +107,7 @@ validate_intent_file_exists:
 delete_intent:
   call: http.post
   args:
-    url: http://node_server:3008/file/delete
+    url: "[#NODE]/file/delete"
     body:
       path: "/mock1/data/nlu/removed/service_${name_res.response.body[0].name}_nlu.tmp"
   result: delete_intent_result

--- a/DSL/Ruuter/POST/services/delete.yml
+++ b/DSL/Ruuter/POST/services/delete.yml
@@ -13,7 +13,7 @@ extract_request_data:
 get_status_name:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-service-name-by-id"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/get-service-name-by-id"
     body:
       id: ${id}
   result: name_res
@@ -22,7 +22,7 @@ get_status_name:
 get_current_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/status"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/status"
     body:
       id: ${id}
   result: status_res
@@ -42,7 +42,7 @@ assign_old_path:
 delete_service:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/delete-service"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/delete-service"
     body:
       id: ${id}
   result: res
@@ -51,7 +51,7 @@ delete_service:
 check_service_file_exists:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/check"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/check"
     body:
       file_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name_res.response.body[0].name}.tmp"
   result: service_file_exists
@@ -66,7 +66,7 @@ validate_service_file_exists:
 delete_deactivated_service:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/delete"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/delete"
     body:
       path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name_res.response.body[0].name}.tmp"
   result: results
@@ -92,7 +92,7 @@ delete_response:
 check_intent_file_exists:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/check"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/check"
     body:
       file_path: "/mock1/data/nlu/removed/service_${name_res.response.body[0].name}_nlu.tmp"
   result: intent_file_exists_result
@@ -107,7 +107,7 @@ validate_intent_file_exists:
 delete_intent:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/delete"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/delete"
     body:
       path: "/mock1/data/nlu/removed/service_${name_res.response.body[0].name}_nlu.tmp"
   result: delete_intent_result

--- a/DSL/Ruuter/POST/services/delete.yml
+++ b/DSL/Ruuter/POST/services/delete.yml
@@ -13,7 +13,7 @@ extract_request_data:
 get_status_name:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/get-service-name-by-id"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-service-name-by-id"
     body:
       id: ${id}
   result: name_res
@@ -22,7 +22,7 @@ get_status_name:
 get_current_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/status"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/status"
     body:
       id: ${id}
   result: status_res
@@ -42,7 +42,7 @@ assign_old_path:
 delete_service:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/delete-service"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/delete-service"
     body:
       id: ${id}
   result: res
@@ -51,7 +51,7 @@ delete_service:
 check_service_file_exists:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/check"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/check"
     body:
       file_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name_res.response.body[0].name}.tmp"
   result: service_file_exists
@@ -66,7 +66,7 @@ validate_service_file_exists:
 delete_deactivated_service:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]/file/delete"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/delete"
     body:
       path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name_res.response.body[0].name}.tmp"
   result: results
@@ -92,7 +92,7 @@ delete_response:
 check_intent_file_exists:
   call: http.post
   args:
-    url: "[#NODE]/file/check"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/check"
     body:
       file_path: "/mock1/data/nlu/removed/service_${name_res.response.body[0].name}_nlu.tmp"
   result: intent_file_exists_result
@@ -107,7 +107,7 @@ validate_intent_file_exists:
 delete_intent:
   call: http.post
   args:
-    url: "[#NODE]/file/delete"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/delete"
     body:
       path: "/mock1/data/nlu/removed/service_${name_res.response.body[0].name}_nlu.tmp"
   result: delete_intent_result

--- a/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-prod-info.yml
+++ b/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-prod-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.post
   args:
-    url: http://localhost:8085/services/endpoints/configs/service-endpoint-prod-configs
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-prod-info.yml
+++ b/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-prod-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/configs/service-endpoint-prod-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-prod-info.yml
+++ b/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-prod-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-prod-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-test-info.yml
+++ b/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-test-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.post
   args:
-    url: http://localhost:8085/services/endpoints/configs/service-endpoint-test-configs
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-test-info.yml
+++ b/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-test-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/configs/service-endpoint-test-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-test-info.yml
+++ b/DSL/Ruuter/POST/services/endpoints/info/service-endpoint-test-info.yml
@@ -1,7 +1,7 @@
 getConfigs:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/configs/service-endpoint-test-configs"
   result: configs
 
 assign_step:

--- a/DSL/Ruuter/POST/services/endpoints/service-endpoint.yml
+++ b/DSL/Ruuter/POST/services/endpoints/service-endpoint.yml
@@ -18,14 +18,14 @@ check_for_environment:
 get_prod_info:
   call: http.post
   args:
-    url: http://localhost:8085/services/endpoints/info/service-endpoint-prod-info
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
   result: info
   next: check_for_endpoint_url
  
 get_test_info:
   call: http.post
   args:
-    url: http://localhost:8085/services/endpoints/info/service-endpoint-test-info
+    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
   result: info 
   next: check_for_endpoint_url
 

--- a/DSL/Ruuter/POST/services/endpoints/service-endpoint.yml
+++ b/DSL/Ruuter/POST/services/endpoints/service-endpoint.yml
@@ -18,14 +18,14 @@ check_for_environment:
 get_prod_info:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
   result: info
   next: check_for_endpoint_url
  
 get_test_info:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
   result: info 
   next: check_for_endpoint_url
 

--- a/DSL/Ruuter/POST/services/endpoints/service-endpoint.yml
+++ b/DSL/Ruuter/POST/services/endpoints/service-endpoint.yml
@@ -18,14 +18,14 @@ check_for_environment:
 get_prod_info:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-prod-info"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/info/service-endpoint-prod-info"
   result: info
   next: check_for_endpoint_url
  
 get_test_info:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/services/endpoints/info/service-endpoint-test-info"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/services/endpoints/info/service-endpoint-test-info"
   result: info 
   next: check_for_endpoint_url
 

--- a/DSL/Ruuter/POST/services/resql/add.yml
+++ b/DSL/Ruuter/POST/services/resql/add.yml
@@ -22,7 +22,7 @@ missing_parameter:
 add_resql:
   call: http.post
   args:
-    url: http://node_server:3008/file/write
+    url: "[#NODE]/file/write"
     body:
       file_path: "/Resql/services/${name}.sql"
       content: ${sql}

--- a/DSL/Ruuter/POST/services/resql/add.yml
+++ b/DSL/Ruuter/POST/services/resql/add.yml
@@ -22,7 +22,7 @@ missing_parameter:
 add_resql:
   call: http.post
   args:
-    url: "[#NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
     body:
       file_path: "/Resql/services/${name}.sql"
       content: ${sql}

--- a/DSL/Ruuter/POST/services/resql/add.yml
+++ b/DSL/Ruuter/POST/services/resql/add.yml
@@ -22,7 +22,7 @@ missing_parameter:
 add_resql:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/write"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/write"
     body:
       file_path: "/Resql/services/${name}.sql"
       content: ${sql}

--- a/DSL/Ruuter/POST/services/search-intents.yml
+++ b/DSL/Ruuter/POST/services/search-intents.yml
@@ -1,7 +1,7 @@
 search_intents:
   call: http.post
   args:
-    url: http://opensearch:9200/intents/_search/template
+    url: "[#SERVICE_OPENSEARCH]/intents/_search/template"
     body:
       id: 'search_intents'
       params: ${incoming.body}

--- a/DSL/Ruuter/POST/services/search-intents.yml
+++ b/DSL/Ruuter/POST/services/search-intents.yml
@@ -1,7 +1,7 @@
 search_intents:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/intents/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#SERVICE_OPENSEARCH_PORT]/intents/_search/template"
     body:
       id: 'search_intents'
       params: ${incoming.body}

--- a/DSL/Ruuter/POST/services/search-intents.yml
+++ b/DSL/Ruuter/POST/services/search-intents.yml
@@ -1,7 +1,7 @@
 search_intents:
   call: http.post
   args:
-    url: "[#SERVICE_OPENSEARCH]/intents/_search/template"
+    url: "[#SERVICE_OPENSEARCH]:[#PORT_OPENSEARCH]/intents/_search/template"
     body:
       id: 'search_intents'
       params: ${incoming.body}

--- a/DSL/Ruuter/POST/services/status.yml
+++ b/DSL/Ruuter/POST/services/status.yml
@@ -15,7 +15,7 @@ check_for_required_parameters:
 get_current_status:
   call: http.post
   args:
-    url: http://resql:8087/status
+    url: "[#SERVICE_RESQL]/status"
     body:
       id: ${id}
   result: status_res
@@ -36,7 +36,7 @@ check_status:
 set_status:
   call: http.post
   args:
-    url: http://resql:8087/set-status
+    url: "[#SERVICE_RESQL]/set-status"
     body:
       id: ${id}
       new_state: ${new_state}
@@ -46,7 +46,7 @@ set_status:
 get_status_name:
   call: http.post
   args:
-    url: http://resql:8087/get-service-name-by-id
+    url: "[#RESQL]/get-service-name-by-id"
     body:
       id: ${id}
   result: name_res
@@ -61,7 +61,7 @@ assign_values:
 check_file_exists:
   call: http.post
   args:
-    url: http://node_server:3008/file/check
+    url: "[#NODE]/file/check"
     body:
       file_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
   result: service_file_exists_result
@@ -82,7 +82,7 @@ check_for_status:
 activate_service:
   call: http.post
   args:
-    url: http://node_server:3008/file/move
+    url: "[#NODE]/file/move"
     body:
       current_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
       new_path: "/Ruuter/${ruuter_type}/services/active/${name}.yml"
@@ -91,7 +91,7 @@ activate_service:
 activate_intent_file:
   call: http.post
   args:
-    url: http://node_server:3008/file/move
+    url: "[#NODE]/file/move"
     body:
       current_path: "/mock1/data/nlu/removed/${service_name}_nlu.tmp"
       new_path: "/mock1/data/nlu/${service_name}_nlu.yml"
@@ -100,13 +100,13 @@ activate_intent_file:
 getFileLocations:
   call: http.get
   args:
-    url: http://host.docker.internal:8080/return-file-locations
+    url: "[#DOCKER_INT]/return-file-locations"
   result: fileLocations
 
 getDomainFile:
   call: http.get
   args:
-    url: http://host.docker.internal:8080/domain-file
+    url: "[#DOCKER_INT]/domain-file"
     headers:
       cookie: ""
   result: domainData
@@ -160,7 +160,7 @@ add_rule:
 deactivate_service:
   call: http.post
   args:
-    url: http://node_server:3008/file/move
+    url: "[#NODE]/file/move"
     body:
       current_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
       new_path: "/Ruuter/${ruuter_type}/services/inactive/${name}.tmp"
@@ -192,7 +192,7 @@ delete_intent:
 rename_intent_to_tmp:
   call: http.post
   args:
-    url: http://node_server:3008/file/move
+    url: "[#NODE]/file/move"
     body:
       current_path: "/mock1/data/nlu/removed/${service_name + '_nlu' + old_file_end}"
       new_path: "/mock1/data/nlu/removed/${service_name}_nlu.tmp"

--- a/DSL/Ruuter/POST/services/status.yml
+++ b/DSL/Ruuter/POST/services/status.yml
@@ -15,7 +15,7 @@ check_for_required_parameters:
 get_current_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/status"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/status"
     body:
       id: ${id}
   result: status_res
@@ -36,7 +36,7 @@ check_status:
 set_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/set-status"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/set-status"
     body:
       id: ${id}
       new_state: ${new_state}
@@ -46,7 +46,7 @@ set_status:
 get_status_name:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-service-name-by-id"
+    url: "[#SERVICE_RESQL]:[#SERVICE_RESQL_PORT]/get-service-name-by-id"
     body:
       id: ${id}
   result: name_res
@@ -61,7 +61,7 @@ assign_values:
 check_file_exists:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/check"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/check"
     body:
       file_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
   result: service_file_exists_result
@@ -82,7 +82,7 @@ check_for_status:
 activate_service:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/move"
     body:
       current_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
       new_path: "/Ruuter/${ruuter_type}/services/active/${name}.yml"
@@ -91,7 +91,7 @@ activate_service:
 activate_intent_file:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/move"
     body:
       current_path: "/mock1/data/nlu/removed/${service_name}_nlu.tmp"
       new_path: "/mock1/data/nlu/${service_name}_nlu.yml"
@@ -100,13 +100,13 @@ activate_intent_file:
 getFileLocations:
   call: http.get
   args:
-    url: "[#SERVICE_DOCKER_INT]:[#PORT_DOCKER_INT]/return-file-locations"
+    url: "[#SERVICE_DOCKER_INT]:[#SERVICE_DOCKER_INT_PORT]/return-file-locations"
   result: fileLocations
 
 getDomainFile:
   call: http.get
   args:
-    url: "[#SERVICE_DOCKER_INT]:[#PORT_DOCKER_INT]/domain-file"
+    url: "[#SERVICE_DOCKER_INT]:[#SERVICE_DOCKER_INT_PORT]/domain-file"
     headers:
       cookie: ""
   result: domainData
@@ -160,7 +160,7 @@ add_rule:
 deactivate_service:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/move"
     body:
       current_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
       new_path: "/Ruuter/${ruuter_type}/services/inactive/${name}.tmp"
@@ -192,7 +192,7 @@ delete_intent:
 rename_intent_to_tmp:
   call: http.post
   args:
-    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#SERVICE_NODE_PORT]/file/move"
     body:
       current_path: "/mock1/data/nlu/removed/${service_name + '_nlu' + old_file_end}"
       new_path: "/mock1/data/nlu/removed/${service_name}_nlu.tmp"

--- a/DSL/Ruuter/POST/services/status.yml
+++ b/DSL/Ruuter/POST/services/status.yml
@@ -15,7 +15,7 @@ check_for_required_parameters:
 get_current_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/status"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/status"
     body:
       id: ${id}
   result: status_res
@@ -36,7 +36,7 @@ check_status:
 set_status:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL]/set-status"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/set-status"
     body:
       id: ${id}
       new_state: ${new_state}
@@ -46,7 +46,7 @@ set_status:
 get_status_name:
   call: http.post
   args:
-    url: "[#RESQL]/get-service-name-by-id"
+    url: "[#SERVICE_RESQL]:[#PORT_RESQL]/get-service-name-by-id"
     body:
       id: ${id}
   result: name_res
@@ -61,7 +61,7 @@ assign_values:
 check_file_exists:
   call: http.post
   args:
-    url: "[#NODE]/file/check"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/check"
     body:
       file_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
   result: service_file_exists_result
@@ -82,7 +82,7 @@ check_for_status:
 activate_service:
   call: http.post
   args:
-    url: "[#NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
     body:
       current_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
       new_path: "/Ruuter/${ruuter_type}/services/active/${name}.yml"
@@ -91,7 +91,7 @@ activate_service:
 activate_intent_file:
   call: http.post
   args:
-    url: "[#NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
     body:
       current_path: "/mock1/data/nlu/removed/${service_name}_nlu.tmp"
       new_path: "/mock1/data/nlu/${service_name}_nlu.yml"
@@ -100,13 +100,13 @@ activate_intent_file:
 getFileLocations:
   call: http.get
   args:
-    url: "[#DOCKER_INT]/return-file-locations"
+    url: "[#SERVICE_DOCKER_INT]:[#PORT_DOCKER_INT]/return-file-locations"
   result: fileLocations
 
 getDomainFile:
   call: http.get
   args:
-    url: "[#DOCKER_INT]/domain-file"
+    url: "[#SERVICE_DOCKER_INT]:[#PORT_DOCKER_INT]/domain-file"
     headers:
       cookie: ""
   result: domainData
@@ -160,7 +160,7 @@ add_rule:
 deactivate_service:
   call: http.post
   args:
-    url: "[#NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
     body:
       current_path: "/Ruuter/${ruuter_type}/services/${old_file_status_path}/${name + old_file_end}"
       new_path: "/Ruuter/${ruuter_type}/services/inactive/${name}.tmp"
@@ -192,7 +192,7 @@ delete_intent:
 rename_intent_to_tmp:
   call: http.post
   args:
-    url: "[#NODE]/file/move"
+    url: "[#SERVICE_NODE]:[#PORT_NODE]/file/move"
     body:
       current_path: "/mock1/data/nlu/removed/${service_name + '_nlu' + old_file_end}"
       new_path: "/mock1/data/nlu/removed/${service_name}_nlu.tmp"

--- a/DSL/Ruuter/POST/templates/RBAC.yml
+++ b/DSL/Ruuter/POST/templates/RBAC.yml
@@ -17,7 +17,7 @@ check_for_required_parameters:
 fetch_user_roles_from_db:
   call: http.post
   args:
-    url: http://resql-users:8088/is-user-roles-allowed
+    url: "[#RESQL_USERS]/is-user-roles-allowed"
     body:
       userId: ${userId}
       allowedRoles: ${allowedRoles}

--- a/DSL/Ruuter/POST/templates/RBAC.yml
+++ b/DSL/Ruuter/POST/templates/RBAC.yml
@@ -17,7 +17,7 @@ check_for_required_parameters:
 fetch_user_roles_from_db:
   call: http.post
   args:
-    url: "[#RESQL_USERS]/is-user-roles-allowed"
+    url: "[#SERVICE_RESQL_USERS]:[#PORT_RESQL_USERS]/is-user-roles-allowed"
     body:
       userId: ${userId}
       allowedRoles: ${allowedRoles}

--- a/DSL/Ruuter/POST/templates/RBAC.yml
+++ b/DSL/Ruuter/POST/templates/RBAC.yml
@@ -17,7 +17,7 @@ check_for_required_parameters:
 fetch_user_roles_from_db:
   call: http.post
   args:
-    url: "[#SERVICE_RESQL_USERS]:[#PORT_RESQL_USERS]/is-user-roles-allowed"
+    url: "[#SERVICE_RESQL_USERS]:[#SERVICE_RESQL_USERS_PORT]/is-user-roles-allowed"
     body:
       userId: ${userId}
       allowedRoles: ${allowedRoles}

--- a/DSL/Ruuter/POST/templates/file-generate.yml
+++ b/DSL/Ruuter/POST/templates/file-generate.yml
@@ -13,7 +13,7 @@ extract_request_data:
 generate_pdf_file:
   call: http.post
   args:
-    url: http://data_mapper:3005/js/generate/pdf
+    url: "[#DMAPPER]/js/generate/pdf"
     body:
       filename: ${fileName}
       template: ${fileContent}

--- a/DSL/Ruuter/POST/templates/file-generate.yml
+++ b/DSL/Ruuter/POST/templates/file-generate.yml
@@ -13,7 +13,7 @@ extract_request_data:
 generate_pdf_file:
   call: http.post
   args:
-    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/js/generate/pdf"
+    url: "[#SERVICE_DMAPPER]:[#SERVICE_DMAPPER_PORT]/js/generate/pdf"
     body:
       filename: ${fileName}
       template: ${fileContent}

--- a/DSL/Ruuter/POST/templates/file-generate.yml
+++ b/DSL/Ruuter/POST/templates/file-generate.yml
@@ -13,7 +13,7 @@ extract_request_data:
 generate_pdf_file:
   call: http.post
   args:
-    url: "[#DMAPPER]/js/generate/pdf"
+    url: "[#SERVICE_DMAPPER]:[#PORT_DMAPPER]/js/generate/pdf"
     body:
       filename: ${fileName}
       template: ${fileContent}

--- a/DSL/Ruuter/POST/templates/tara.yml
+++ b/DSL/Ruuter/POST/templates/tara.yml
@@ -1,7 +1,7 @@
 request_tim_user_info:
   call: http.post
   args:
-    url: http://localhost:8085/mocks/tim/user-info
+    url: "[#SERVICE_ENDPOINTS]/mocks/tim/user-info"
   result: result
 
 return_value:

--- a/DSL/Ruuter/POST/templates/tara.yml
+++ b/DSL/Ruuter/POST/templates/tara.yml
@@ -1,7 +1,7 @@
 request_tim_user_info:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/mocks/tim/user-info"
+    url: "[#SERVICE_ENDPOINTS]:[#SERVICE_ENDPOINTS_PORT]/mocks/tim/user-info"
   result: result
 
 return_value:

--- a/DSL/Ruuter/POST/templates/tara.yml
+++ b/DSL/Ruuter/POST/templates/tara.yml
@@ -1,7 +1,7 @@
 request_tim_user_info:
   call: http.post
   args:
-    url: "[#SERVICE_ENDPOINTS]/mocks/tim/user-info"
+    url: "[#SERVICE_ENDPOINTS]:[#PORT_ENDPOINTS]/mocks/tim/user-info"
   result: result
 
 return_value:


### PR DESCRIPTION
Fixed parameters in the Ruuter DSL file URLs by adding PORT parameters and fixing some earlier url parameters by adding "SERVICE_". Example [#SERVICE_DMAPPER] -> [#SERVICE_DMAPPER]:[#PORT_DMAPPER] in the url. A total of 40 files were changed. To be determined how the url for http://ruuter:8085/ , http://localhost:8080/ and http://host.docker.internal:3000/ will be changed.
Issue https://github.com/buerokratt/Service-Module/issues/128