### PR TITLE
Hotfix: Node Server

### DIFF
--- a/DSL/Node/src/file.ts
+++ b/DSL/Node/src/file.ts
@@ -26,6 +26,8 @@ router.post("/write", (req, res) => {
     return;
   }
 
+  fs.mkdir(path.dirname(filename), () => { });
+
   fs.writeFile(filename, content, (err) => {
     if (err) {
       res.status(500).json({ message: "Unable to save file" });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
     volumes:
       - ./DSL:/data
       - ./DSL/Node:/app
+      - /app/node_modules
     ports:
       - 3008:3008
     networks:


### PR DESCRIPTION
Fixed Node server following issues:

1. `node_modules` not being generated on container start.
2. Save to file fails when the file is not already there.