### PR TITLE
Fix running GUI locally

### DIFF
--- a/GUI/package.json
+++ b/GUI/package.json
@@ -17,7 +17,6 @@
     "@tanstack/match-sorter-utils": "^8.7.6",
     "@tanstack/react-query": "^4.23.0",
     "@tanstack/react-table": "^8.7.9",
-    "@vitejs/plugin-react": "^4.0.4",
     "axios": "^1.2.2",
     "axios-mock-adapter": "^1.21.5",
     "clsx": "^1.2.1",
@@ -55,9 +54,6 @@
     "to-json-schema": "^0.2.5",
     "typescript": "^4.9.4",
     "uuid": "^9.0.0",
-    "vite": "^4.4.9",
-    "vite-plugin-svgr": "^3.2.0",
-    "vite-tsconfig-paths": "^4.2.0",
     "yup": "^1.0.0"
   },
   "scripts": {
@@ -84,10 +80,11 @@
     "@types/react-dom": "^18.0.10",
     "@types/to-json-schema": "^0.2.1",
     "@types/uuid": "^9.0.1",
-    "vite": "^4.0.0",
-    "vite-plugin-env-compatible": "^1.1.1",
-    "vite-plugin-svgr": "^2.4.0",
-    "vite-tsconfig-paths": "^4.0.3"
+    "@vitejs/plugin-react": "^4.0.4",
+    "vite": "^4.4.9",
+    "vite-plugin-svgr": "^3.2.0",
+    "vite-tsconfig-paths": "^4.2.0",
+    "vite-plugin-env-compatible": "^1.1.1"
   },
   "msw": {
     "workerDirectory": "public"

--- a/GUI/package.json
+++ b/GUI/package.json
@@ -84,8 +84,6 @@
     "@types/react-dom": "^18.0.10",
     "@types/to-json-schema": "^0.2.1",
     "@types/uuid": "^9.0.1",
-    "@vitejs/plugin-react": "^3.0.0",
-    "react-scripts": "^5.0.1",
     "vite": "^4.0.0",
     "vite-plugin-env-compatible": "^1.1.1",
     "vite-plugin-svgr": "^2.4.0",


### PR DESCRIPTION
This PR fixes running GUI locally.

- There were duplicate Vite dependencies **with different versions**, this was probably causing conflicts. Cleaned this up.
- Removed `react-scripts` removed from dependencies, it is a part of CRA and should never be used with Vite. Perhaps this was some leftover?

Can be tested with `docker-compose down && docker-compose build --no-cache && docker-compose up` or likely just rebuilding the `gui_dev` image.