### PR TITLE
Fix: Muuda triggers console error after dragging message block

### DIFF
--- a/GUI/package.json
+++ b/GUI/package.json
@@ -82,9 +82,9 @@
     "@types/uuid": "^9.0.1",
     "@vitejs/plugin-react": "^4.0.4",
     "vite": "^4.4.9",
-    "vite-plugin-env-compatible": "^1.1.1",
     "vite-plugin-svgr": "^3.2.0",
-    "vite-tsconfig-paths": "^4.2.0"
+    "vite-tsconfig-paths": "^4.2.0",
+    "vite-plugin-env-compatible": "^1.1.1"
   },
   "msw": {
     "workerDirectory": "public"

--- a/GUI/package.json
+++ b/GUI/package.json
@@ -44,7 +44,7 @@
     "react-icons": "^4.7.1",
     "react-idle-timer": "^5.7.2",
     "react-json-tree": "^0.20.0",
-    "react-quill": "^2.0.0",
+    "react-quill-new": "^3.4.6",
     "react-router-dom": "^6.6.2",
     "react-textarea-autosize": "^8.4.0",
     "reactflow": "^11.7.0",
@@ -82,9 +82,9 @@
     "@types/uuid": "^9.0.1",
     "@vitejs/plugin-react": "^4.0.4",
     "vite": "^4.4.9",
+    "vite-plugin-env-compatible": "^1.1.1",
     "vite-plugin-svgr": "^3.2.0",
-    "vite-tsconfig-paths": "^4.2.0",
-    "vite-plugin-env-compatible": "^1.1.1"
+    "vite-tsconfig-paths": "^4.2.0"
   },
   "msw": {
     "workerDirectory": "public"

--- a/GUI/src/components/FormElements/FormRichText/index.tsx
+++ b/GUI/src/components/FormElements/FormRichText/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
-import ReactQuill from "react-quill";
-import 'react-quill/dist/quill.snow.css';
+import ReactQuill from "react-quill-new";
+import 'react-quill-new/dist/quill.snow.css';
 import './FormRichText.scss';
 
 type FormRichTextProps = {


### PR DESCRIPTION
Important Notes:

- Removed `react-quill` as its not maintained anymore
- Added `react-quill-new` instead which does the same and solves the deprecation issues

Related Task:

- https://github.com/buerokratt/Service-Module/issues/503