### PR TITLE
Bug fix - Clear current service state on browser "back" button press #933

### DIFF
--- a/GUI/src/pages/ServiceFlowPage.tsx
+++ b/GUI/src/pages/ServiceFlowPage.tsx
@@ -74,15 +74,15 @@ const ServiceFlowPage: FC = () => {
         }}
         saveOnClick={async () => {
           setHasUnsavedChanges(false);
-          if (!id) {
+          if (id) {
+            await useServiceStore.getState().loadService(id);
+          } else {
             const serviceId = useServiceStore.getState().serviceId;
             const serviceResponse = await useServiceStore.getState().loadService(serviceId);
             if (serviceResponse) {
               useServiceListStore.getState().setSelectedService(serviceResponse?.data);
               navigate(ROUTES.replaceWithId(ROUTES.EDITSERVICE_ROUTE, serviceId));
             }
-          } else {
-            await useServiceStore.getState().loadService(id);
           }
         }}
       />

--- a/GUI/src/pages/ServiceFlowPage.tsx
+++ b/GUI/src/pages/ServiceFlowPage.tsx
@@ -46,6 +46,11 @@ const ServiceFlowPage: FC = () => {
     };
 
     void loadData();
+
+    // Cleanup function to reset state when component unmounts (including browser back button)
+    return () => {
+      useServiceStore.getState().resetState();
+    };
   }, [id]);
 
   const edges = useServiceStore((state) => state.edges);

--- a/GUI/src/store/new-services.store.ts
+++ b/GUI/src/store/new-services.store.ts
@@ -391,6 +391,8 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
       serviceId: uuid(),
       description: '',
       slot: '',
+      examples: [],
+      entities: [],
       secrets: { prod: [], test: [] },
       availableVariables: { prod: [], test: [] },
       isCommon: false,

--- a/GUI/src/store/new-services.store.ts
+++ b/GUI/src/store/new-services.store.ts
@@ -229,7 +229,7 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
   unmarkAsNewService: () => set({ isNewService: false }),
   setServiceId: (id) => set({ serviceId: id }),
   setNodes: (nodes) => {
-    if (nodes instanceof Function) {
+    if (typeof nodes === 'function') {
       set((state) => {
         return {
           nodes: nodes(state.nodes),
@@ -240,7 +240,7 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
     }
   },
   setEdges: (edges) => {
-    if (edges instanceof Function) {
+    if (typeof edges === 'function') {
       set((state) => {
         return {
           edges: edges(state.edges),
@@ -294,17 +294,18 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
           });
         }
 
-        chips.push({
-          name: 'Base Response',
-          value: `${endpoint?.name.replaceAll(' ', '_')}_res.response.body`,
-          data: `${endpoint?.name.replaceAll(' ', '_')}_res.response.body`,
-        });
-
-        chips.push({
-          name: 'Status Code',
-          value: `${endpoint?.name.replaceAll(' ', '_')}_res.response.statusCodeValue`,
-          data: `${endpoint?.name.replaceAll(' ', '_')}_res.response.statusCodeValue`,
-        });
+        chips.push(
+          {
+            name: 'Base Response',
+            value: `${endpoint?.name.replaceAll(' ', '_')}_res.response.body`,
+            data: `${endpoint?.name.replaceAll(' ', '_')}_res.response.body`,
+          },
+          {
+            name: 'Status Code',
+            value: `${endpoint?.name.replaceAll(' ', '_')}_res.response.statusCodeValue`,
+            data: `${endpoint?.name.replaceAll(' ', '_')}_res.response.statusCodeValue`,
+          }
+        );
 
         const variable: EndpointResponseVariable = {
           name: endpoint?.name ?? '',
@@ -440,7 +441,7 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
 
       if (!nodes || nodes.length === 0) nodes = initialNodes;
 
-      if (!endpoints || !(endpoints instanceof Array)) endpoints = [];
+      if (!endpoints || !Array.isArray(endpoints)) endpoints = [];
 
       nodes = nodes.map((node: any) => {
         if (node.type !== 'custom') return node;
@@ -679,7 +680,7 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
         title: i18next.t('newService.toast.missingFields'),
         message: i18next.t('newService.toast.serviceMissingFields'),
       });
-      return Promise.reject(new Error(i18next.t('newService.toast.missingFields') ?? 'Error'));
+      throw new Error(i18next.t('newService.toast.missingFields') ?? 'Error');
     }
 
     const { isNewService, onServiceSave } = get();
@@ -687,7 +688,7 @@ const useServiceStore = create<ServiceStoreState>((set, get) => ({
     try {
       await onServiceSave(ServiceState.Ready);
     } catch (e: any) {
-      return Promise.reject(new Error(i18next.t('toast.cannot-save-flow') ?? (e?.message as string) ?? 'Error'));
+      throw new Error(i18next.t('toast.cannot-save-flow') ?? (e?.message as string) ?? 'Error');
     }
 
     if (isNewService) {


### PR DESCRIPTION
This pull request introduces improvements to state management and initialization for the service flow functionality. The main changes ensure proper cleanup of state when navigating away from the page and enhance the default structure of new services.

State management improvements:

* Added a cleanup function in the `ServiceFlowPage` component to reset the service store state when the component unmounts, ensuring consistent behavior including when using the browser back button.

Service initialization enhancements:

* Modified the service store's default state to include empty `examples` and `entities` arrays for new services, improving the clarity and completeness of the initial service object.