### PR TITLE
Bug fix - Broken Links & HTML Artifacts in Message to Client #932

### DIFF
--- a/DSL/DMapper/services/hbs/bot_responses_to_messages.handlebars
+++ b/DSL/DMapper/services/hbs/bot_responses_to_messages.handlebars
@@ -2,7 +2,7 @@
 {{#each data.botMessages}}
   {
    "chatId": "{{../data.chatId}}",
-   "content": "{{filterControlCharacters result}}",
+  "content": "{{{filterControlCharacters (escapeQuotes result)}}}",
    "buttons": "[{{#each ../data.buttons}}{\"title\": \"{{#if (eq title true)}}Yes{{else if (eq title false)}}No{{else}}{{{title}}}{{/if}}\",\"payload\": \"{{{payload}}}\"}{{#unless @last}},{{/unless}}{{/each}}]",
    "authorTimestamp": "{{../data.authorTimestamp}}",
    "authorId": "{{../data.authorId}}",

--- a/GUI/src/components/Flow/NodeTypes/StepNode.tsx
+++ b/GUI/src/components/Flow/NodeTypes/StepNode.tsx
@@ -63,7 +63,7 @@ const StepNode: FC<StepNodeProps> = ({ data }) => {
   }, [data, endpoints]);
 
   useEffect(() => {
-    void updateIsTestedAndPassed();
+    updateIsTestedAndPassed();
   }, [updateIsTestedAndPassed]);
 
   return (

--- a/GUI/src/components/Flow/NodeTypes/StepNode.tsx
+++ b/GUI/src/components/Flow/NodeTypes/StepNode.tsx
@@ -3,10 +3,12 @@ import ExclamationBadge from 'components/ExclamationBadge';
 import Track from 'components/Track';
 import { FC, memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import sanitizeHtml from 'sanitize-html';
 import useServiceStore from 'store/new-services.store';
 import { StepType } from 'types';
 import { NodeDataProps } from 'types/service-flow';
 import { validateStep } from 'utils/flow-utils';
+import { decodeHtmlEntities } from 'utils/string-util';
 
 type StepNodeProps = {
   data: NodeDataProps;
@@ -21,8 +23,17 @@ const StepNode: FC<StepNodeProps> = ({ data }) => {
     fontWeight: 500,
   };
   const createMarkup = (text: string) => {
+    const decodedText = decodeHtmlEntities(text);
+    const sanitizedText = sanitizeHtml(decodedText, {
+      allowedTags: ['a', 'b', 'strong', 'i', 'em', 'u', 'p', 'br', 'ul', 'ol', 'li', 'code'],
+      allowedAttributes: {
+        a: ['href', 'target', 'rel'],
+      },
+      disallowedTagsMode: 'discard',
+    });
+
     return {
-      __html: text,
+      __html: sanitizedText,
     };
   };
 

--- a/GUI/src/components/Flow/NodeTypes/StepNode.tsx
+++ b/GUI/src/components/Flow/NodeTypes/StepNode.tsx
@@ -63,7 +63,7 @@ const StepNode: FC<StepNodeProps> = ({ data }) => {
   }, [data, endpoints]);
 
   useEffect(() => {
-    updateIsTestedAndPassed();
+    void updateIsTestedAndPassed();
   }, [updateIsTestedAndPassed]);
 
   return (

--- a/GUI/src/components/Flow/NodeTypes/StepNode.tsx
+++ b/GUI/src/components/Flow/NodeTypes/StepNode.tsx
@@ -63,7 +63,9 @@ const StepNode: FC<StepNodeProps> = ({ data }) => {
   }, [data, endpoints]);
 
   useEffect(() => {
-    void updateIsTestedAndPassed();
+    updateIsTestedAndPassed().catch(() => {
+      setIsTestedAndPassed(false);
+    });
   }, [updateIsTestedAndPassed]);
 
   return (

--- a/GUI/src/components/Markdowify/index.tsx
+++ b/GUI/src/components/Markdowify/index.tsx
@@ -72,6 +72,16 @@ const LinkPreview: React.FC<{
 
 const hasSpecialFormat = (m: string) => m.includes('\n\n') && m.indexOf('.') > 0 && m.indexOf(':') > m.indexOf('.');
 
+const htmlLinkToMarkdown = (value: string): string =>
+  value.replaceAll(
+    /<a\s+[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi,
+    (_, href1: string, href2: string, href3: string, label: string) => {
+      const href = (href1 ?? href2 ?? href3 ?? '').trim();
+      const text = sanitizeHtml(label ?? '', { allowedTags: [], allowedAttributes: {} }).trim() || href;
+      return href ? `[${text}](${href})` : text;
+    },
+  );
+
 function formatMessage(message?: string): string {
   const sanitizedMessage = sanitizeHtml(message ?? '');
 
@@ -87,8 +97,9 @@ function formatMessage(message?: string): string {
     dataImagePattern,
     (_, prefix, dataUrl) => `${prefix}[image](${dataUrl})`,
   );
+  const markdownLinksMessage = htmlLinkToMarkdown(finalMessage);
 
-  return finalMessage
+  return markdownLinksMessage
     .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')

--- a/GUI/src/components/Markdowify/index.tsx
+++ b/GUI/src/components/Markdowify/index.tsx
@@ -72,15 +72,21 @@ const LinkPreview: React.FC<{
 
 const hasSpecialFormat = (m: string) => m.includes('\n\n') && m.indexOf('.') > 0 && m.indexOf(':') > m.indexOf('.');
 
-const htmlLinkToMarkdown = (value: string): string =>
-  value.replaceAll(
-    /<a\s+[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>((?:[^<]|<(?!\/a>))*)<\/a>/gi,
-    (_, href1: string, href2: string, href3: string, label: string) => {
-      const href = (href1 ?? href2 ?? href3 ?? '').trim();
-      const text = sanitizeHtml(label ?? '', { allowedTags: [], allowedAttributes: {} }).trim() || href;
-      return href ? `[${text}](${href})` : text;
-    },
-  );
+const htmlLinkToMarkdown = (value: string): string => {
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = value;
+  const links = tempDiv.querySelectorAll('a');
+  
+  let result = value;
+  links.forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    const text = link.textContent || href;
+    const markdown = href ? `[${text}](${href})` : text;
+    result = result.replace(link.outerHTML, markdown);
+  });
+  
+  return result;
+};
 
 function formatMessage(message?: string): string {
   const sanitizedMessage = sanitizeHtml(message ?? '');

--- a/GUI/src/components/Markdowify/index.tsx
+++ b/GUI/src/components/Markdowify/index.tsx
@@ -74,7 +74,7 @@ const hasSpecialFormat = (m: string) => m.includes('\n\n') && m.indexOf('.') > 0
 
 const htmlLinkToMarkdown = (value: string): string =>
   value.replaceAll(
-    /<a\s+[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi,
+    /<a\s+[^>]*href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>((?:[^<]|<(?!\/a>))*)<\/a>/gi,
     (_, href1: string, href2: string, href3: string, label: string) => {
       const href = (href1 ?? href2 ?? href3 ?? '').trim();
       const text = sanitizeHtml(label ?? '', { allowedTags: [], allowedAttributes: {} }).trim() || href;
@@ -100,7 +100,7 @@ function formatMessage(message?: string): string {
   const markdownLinksMessage = htmlLinkToMarkdown(finalMessage);
 
   return markdownLinksMessage
-    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
+    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')
     .replaceAll('&lt;', '<')
@@ -116,7 +116,7 @@ function formatMessage(message?: string): string {
           return `${prefix}${year}. `;
         }
       }
-      return `${prefix}${year}\\. `;
+      return String.raw`${prefix}${year}\. `;
     })
     .replaceAll(/(?<=\n)\d+\.\s/g, hasSpecialFormat(finalMessage) ? '\n\n$&' : '$&')
     .replaceAll(/^(\s+)/g, (match) => match.replaceAll(' ', '&nbsp;'));

--- a/GUI/src/components/chat/bot-message.tsx
+++ b/GUI/src/components/chat/bot-message.tsx
@@ -22,7 +22,6 @@ interface ChatMessageProps {
 
 const BotMessage = ({ message }: ChatMessageProps) => {
   const renderContent = useCallback(() => {
-    if (message.message.startsWith('<p>')) return message.message.replace('<p>', '').replace('</p>', '');
     return <Markdownify message={message.message} />;
   }, [message.message]);
 

--- a/GUI/src/components/chat/chat.module.scss
+++ b/GUI/src/components/chat/chat.module.scss
@@ -141,6 +141,16 @@
       .content {
         border-radius: 6px 48px 48px 29px;
         background-color: blue;
+        color: white;
+
+        a {
+          color: #a8d4ff;
+          text-decoration: underline;
+
+          &:visited {
+            color: #c8a8ff;
+          }
+        }
       }
 
       .icon {
@@ -378,6 +388,16 @@
     .main {
       .content {
         background-color: get-color(sapphire-blue-12);
+        color: var(--dark-bg-extra-light);
+
+        a {
+          color: #a8d4ff;
+          text-decoration: underline;
+
+          &:visited {
+            color: #c8a8ff;
+          }
+        }
       }
     }
   }

--- a/GUI/src/components/chat/chat.module.scss
+++ b/GUI/src/components/chat/chat.module.scss
@@ -284,12 +284,12 @@
 
   &.error {
     color: rgb(80, 0, 0);
-    background: #f002;
+    background: #ffe3e3;
   }
 
   &.info {
     color: rgb(0, 0, 80);
-    background: #00f2;
+    background: #e3e8ff;
   }
 
   &.normal {

--- a/GUI/src/components/chat/chat.module.scss
+++ b/GUI/src/components/chat/chat.module.scss
@@ -233,7 +233,7 @@
       pointer-events: none;
       user-select: none;
       background-color: #f5f5f5;
-      color: #999;
+      color: #696969;
     }
   }
 
@@ -278,17 +278,17 @@
   font-weight: bold;
 
   &.success {
-    color: rgb(0, 138, 0);
+    color: rgb(0, 100, 0);
     background: #0f02;
   }
 
   &.error {
-    color: rgb(170, 0, 0);
+    color: rgb(153, 0, 0);
     background: #f002;
   }
 
   &.info {
-    color: rgb(0, 0, 203);
+    color: rgb(0, 0, 153);
     background: #00f2;
   }
 

--- a/GUI/src/components/chat/chat.module.scss
+++ b/GUI/src/components/chat/chat.module.scss
@@ -283,12 +283,12 @@
   }
 
   &.error {
-    color: rgb(153, 0, 0);
+    color: rgb(80, 0, 0);
     background: #f002;
   }
 
   &.info {
-    color: rgb(0, 0, 153);
+    color: rgb(0, 0, 80);
     background: #00f2;
   }
 

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -880,9 +880,7 @@ export const saveFlowClick = async (status: 'draft' | 'ready' = 'ready', showErr
   const nodes = useServiceStore.getState().nodes as Node<NodeDataProps>[];
 
   await saveFlow({
-    name: name
-      ? name
-      : `${t('newService.defaultServiceName').toString()}_${format(new Date(), 'dd_MM_yyyy_HH_mm_ss')}`,
+    name: name || `${t('newService.defaultServiceName').toString()}_${format(new Date(), 'dd_MM_yyyy_HH_mm_ss')}`,
     edges,
     nodes,
     onSuccess: () => {

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -12,6 +12,7 @@ import { Assign } from 'types/assign';
 import { EndpointData } from 'types/endpoint';
 import { NodeDataProps } from 'types/service-flow';
 import {
+  decodeHtmlEntities,
   getLastDigits,
   isNumericString,
   removeTrailingUnderscores,
@@ -602,11 +603,10 @@ function handleTextField(
   });
 
   const spacePlaceholder = '___SPACE___';
+  const rawMessage = typeof parentNode.data.message === 'string' ? decodeHtmlEntities(parentNode.data.message) : '';
   const markdownMessage = htmlToMarkdown
     .translate(
-      typeof parentNode.data.message === 'string'
-        ? parentNode.data.message.replace('{{', '${').replace('}}', '}').replaceAll(' ', spacePlaceholder)
-        : '',
+      rawMessage.replace('{{', '${').replace('}}', '}').replaceAll(' ', spacePlaceholder),
     )
     .replaceAll(spacePlaceholder, ' ')
     .replaceAll(/\\([-~>[\]_*#().!`=<\\])/g, String.raw`\\$1`);

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -189,7 +189,7 @@ export const saveFlow = async ({
 
     const mcqNodes = nodes.filter(
       (node) => node.data?.stepType === StepType.MultiChoiceQuestion,
-    ) as Node<NodeDataProps>[];
+    );
 
     if (mcqNodes.length > 0) {
       const nodesUpToFirstMcq = nodes.slice(
@@ -421,7 +421,7 @@ export function getYamlContent(
   try {
     allRelations.forEach((r) => {
       const [parentNodeId, childNodeId] = r.split(',');
-      const parentNode = nodes.findLast((node) => node.id === parentNodeId) as Node<NodeDataProps> | undefined;
+      const parentNode = nodes.findLast((node) => node.id === parentNodeId);
       if (
         !parentNode?.type ||
         parentNode.type !== 'custom' ||
@@ -430,7 +430,7 @@ export function getYamlContent(
         return;
       }
 
-      const childNode = nodes.find((node) => node.id === childNodeId) as Node<NodeDataProps> | undefined;
+      const childNode = nodes.find((node) => node.id === childNodeId);
       const parentStepName = toSnakeCase(parentNode.data.label);
 
       if (parentNode.data.stepType === StepType.Textfield) {
@@ -631,7 +631,7 @@ function handleTextField(
 function handleConditionStep(
   allRelations: any[],
   parentNodeId: any,
-  nodes: Node[],
+  nodes: Node<NodeDataProps>[],
   parentNode: Node<NodeDataProps>,
   finishedFlow: Map<any, any>,
   parentStepName: string,
@@ -640,8 +640,8 @@ function handleConditionStep(
   const firstChildNode = conditionRelations[0].split(',')[1];
   const secondChildNode = conditionRelations[1].split(',')[1];
 
-  const firstChild = nodes.find((node) => node.id === firstChildNode) as Node<NodeDataProps> | undefined;
-  const secondChild = nodes.find((node) => node.id === secondChildNode) as Node<NodeDataProps> | undefined;
+  const firstChild = nodes.find((node) => node.id === firstChildNode);
+  const secondChild = nodes.find((node) => node.id === secondChildNode);
 
   const rulesChildren = Array.isArray(parentNode.data.rules?.children) ? parentNode.data.rules.children : [];
   const invalidRulesExist = hasInvalidRules(rulesChildren);
@@ -880,9 +880,9 @@ export const saveFlowClick = async (status: 'draft' | 'ready' = 'ready', showErr
   const nodes = useServiceStore.getState().nodes as Node<NodeDataProps>[];
 
   await saveFlow({
-    name: !name
-      ? `${t('newService.defaultServiceName').toString()}_${format(new Date(), 'dd_MM_yyyy_HH_mm_ss')}`
-      : name,
+    name: name
+      ? name
+      : `${t('newService.defaultServiceName').toString()}_${format(new Date(), 'dd_MM_yyyy_HH_mm_ss')}`,
     edges,
     nodes,
     onSuccess: () => {

--- a/GUI/src/utils/string-util.ts
+++ b/GUI/src/utils/string-util.ts
@@ -163,7 +163,7 @@ export function decodeHtmlEntities(value: string): string {
 
   return value
     .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
-    .replaceAll(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(parseInt(code, 10)))
+    .replaceAll(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 10)))
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')
     .replaceAll('&lt;', '<')

--- a/GUI/src/utils/string-util.ts
+++ b/GUI/src/utils/string-util.ts
@@ -151,3 +151,23 @@ export function removeWrapperQuotes(str: string): string {
 
   return str.substring(start, end + 1);
 }
+
+export function decodeHtmlEntities(value: string): string {
+  if (typeof value !== 'string' || value.length === 0) return value;
+
+  if (typeof document !== 'undefined') {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = value;
+    return textarea.value;
+  }
+
+  return value
+    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
+    .replaceAll(/&#(\d+);/g, (_, code: string) => String.fromCharCode(parseInt(code, 10)))
+    .replaceAll('&amp;', '&')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&apos;', "'");
+}

--- a/GUI/src/utils/string-util.ts
+++ b/GUI/src/utils/string-util.ts
@@ -24,7 +24,7 @@ export const templateToString = (value: string | number) => {
 };
 
 export const toSnakeCase = (value: string) => {
-  return value.toLowerCase().trim().replace(/\s+/g, '_').replace(/-+/g, '_').replace(/_+/g, '_');
+  return value.toLowerCase().trim().replaceAll(/\s+/g, '_').replaceAll(/-+/g, '_').replaceAll(/_+/g, '_');
 };
 
 export const fromSnakeCase = (value: string) => {
@@ -96,7 +96,7 @@ export function removeNestedTemplates(str: string): string {
     changed = false;
     iterationCount++;
 
-    str = str.replace(
+    str = str.replaceAll(
       /\$\{([^${}]*)\$\{([^}]*)\}([^}]*)\}/g,
       (match: string, p1: string, p2: string, p3: string): string => {
         changed = true;
@@ -116,7 +116,7 @@ export function removeNestedTemplates(str: string): string {
     changed = false;
     iterationCount++;
 
-    str = str.replace(
+    str = str.replaceAll(
       /\$\{([^{}]*)\{([^}]*)\}([^}]*)\}/g,
       (match: string, p1: string, p2: string, p3: string): string => {
         changed = true;
@@ -162,8 +162,8 @@ export function decodeHtmlEntities(value: string): string {
   }
 
   return value
-    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)))
-    .replaceAll(/&#(\d+);/g, (_, code: string) => String.fromCharCode(parseInt(code, 10)))
+    .replaceAll(/&#x([0-9A-F]+);/gi, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replaceAll(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(parseInt(code, 10)))
     .replaceAll('&amp;', '&')
     .replaceAll('&gt;', '>')
     .replaceAll('&lt;', '<')


### PR DESCRIPTION
#932

This fix includes a change in Buerokratt-Chatbot also.

PR in chatbot: https://github.com/buerokratt/Buerokratt-Chatbot/pull/1826

...............................................................................................................................................................

This pull request introduces improvements to how HTML content and links are handled and displayed in bot messages, step nodes, and chat components. It adds robust HTML entity decoding, sanitizes HTML to prevent unsafe content, and ensures links are properly converted and styled. These changes enhance security, readability, and user experience across the interface.

**HTML Decoding and Sanitization Enhancements:**

* Added `decodeHtmlEntities` utility in `string-util.ts` to reliably decode HTML entities, used throughout the codebase for safer and clearer text rendering.
* Updated `StepNode` (`StepNode.tsx`) to decode and sanitize HTML content before rendering, allowing only safe tags and attributes. [[1]](diffhunk://#diff-ff5ea30b5c72c477cbdfa74aecd2a9dd8bb1f5671090a5a902a021259c208229R6-R11) [[2]](diffhunk://#diff-ff5ea30b5c72c477cbdfa74aecd2a9dd8bb1f5671090a5a902a021259c208229R26-R36)
* Modified message processing in `service-builder.ts` to decode HTML entities before converting to markdown, improving accuracy and safety. [[1]](diffhunk://#diff-ef15470d7e7976d192ac73cd8a9c432bfec2f9474a4198921e0aacd4fe4e043fR15) [[2]](diffhunk://#diff-ef15470d7e7976d192ac73cd8a9c432bfec2f9474a4198921e0aacd4fe4e043fR606-R609)

**Link Handling and Markdown Conversion:**

* Introduced `htmlLinkToMarkdown` in `Markdowify/index.tsx` to convert HTML `<a>` tags into markdown links, ensuring consistent formatting and safer rendering in bot messages. [[1]](diffhunk://#diff-f1565bb40ab5a034609f5caee2e77dadd5b590bcca44ab415e830cbcdf1ad91cR75-R84) [[2]](diffhunk://#diff-f1565bb40ab5a034609f5caee2e77dadd5b590bcca44ab415e830cbcdf1ad91cR100-R102)

**UI and Styling Improvements:**

* Enhanced chat message styling in `chat.module.scss` to improve link visibility, including custom colors for regular and visited links, and improved text contrast. [[1]](diffhunk://#diff-830cb3a93f039a460b920730132c581a849fd507887aad25ca1d1f74330820ddR144-R153) [[2]](diffhunk://#diff-830cb3a93f039a460b920730132c581a849fd507887aad25ca1d1f74330820ddR391-R400)

**Bot Message Rendering:**

* Updated bot message rendering to consistently use markdown formatting, removing legacy HTML stripping logic for `<p>` tags.

**Backend Template Update:**

* Improved bot response template (`bot_responses_to_messages.handlebars`) to escape quotes and filter control characters for safer and more reliable message content.