### PR TITLE
Fix for bug #944 - MCQ nodes share button state causing errors

### DIFF
--- a/GUI/src/components/FlowElementsPopup/index.tsx
+++ b/GUI/src/components/FlowElementsPopup/index.tsx
@@ -85,6 +85,12 @@ const FlowElementsPopup: React.FC = () => {
     [],
   );
 
+  // Copy buttons to avoid shared object references between popup state and node data.
+  const copyMcqButtons = (buttons: MultiChoiceQuestionButton[]) =>
+    buttons.map((button) => ({
+      ...button,
+    }));
+
   // StepType.Textfield
   const [textfieldMessage, setTextfieldMessage] = useState<string | null>(null);
   const [textfieldMessagePlaceholders, setTextfieldMessagePlaceholders] = useState<{ [key: string]: string }>({});
@@ -101,7 +107,7 @@ const FlowElementsPopup: React.FC = () => {
     node?.data.multiChoiceQuestion?.question ?? '',
   );
   const [multiChoiceQuestionButtons, setMultiChoiceQuestionButtons] = useState<MultiChoiceQuestionButton[]>(
-    node?.data.multiChoiceQuestion?.buttons ?? defaultMultiChoiceQuestionButtons,
+    copyMcqButtons(node?.data.multiChoiceQuestion?.buttons ?? defaultMultiChoiceQuestionButtons),
   );
   const [dynamicChoices, setDynamicChoices] = useState<DynamicChoices>(
     node?.data.dynamicChoices ?? defaultDynamicChoices,
@@ -136,7 +142,9 @@ const FlowElementsPopup: React.FC = () => {
 
       case StepType.MultiChoiceQuestion:
         setMultiChoiceQuestionQuestion(node.data?.multiChoiceQuestion?.question ?? '');
-        setMultiChoiceQuestionButtons(node.data?.multiChoiceQuestion?.buttons ?? defaultMultiChoiceQuestionButtons);
+        setMultiChoiceQuestionButtons(
+          copyMcqButtons(node.data?.multiChoiceQuestion?.buttons ?? defaultMultiChoiceQuestionButtons),
+        );
         break;
 
       case StepType.DynamicChoices:
@@ -163,7 +171,7 @@ const FlowElementsPopup: React.FC = () => {
     setFileContent(null);
     setTextfieldMessagePlaceholders({});
     setMultiChoiceQuestionQuestion('');
-    setMultiChoiceQuestionButtons(defaultMultiChoiceQuestionButtons);
+    setMultiChoiceQuestionButtons(copyMcqButtons(defaultMultiChoiceQuestionButtons));
     setIsSaveEnabled(true);
     setDynamicChoices(defaultDynamicChoices);
     useServiceStore.getState().resetSelectedNode();
@@ -187,7 +195,7 @@ const FlowElementsPopup: React.FC = () => {
           node.data.stepType === StepType.MultiChoiceQuestion
             ? {
                 question: multiChoiceQuestionQuestion,
-                buttons: multiChoiceQuestionButtons,
+                buttons: copyMcqButtons(multiChoiceQuestionButtons),
               }
             : undefined,
         dynamicChoices: node.data.stepType === StepType.DynamicChoices ? dynamicChoices : undefined,
@@ -339,8 +347,10 @@ const FlowElementsPopup: React.FC = () => {
   const saveMultiChoicePopup = (originalNode: Node<NodeDataProps>, updatedNode: Node<NodeDataProps>) => {
     if (!instance) return;
 
-    const currentButtons = originalNode.data.multiChoiceQuestion?.buttons ?? defaultMultiChoiceQuestionButtons;
-    const newButtons = updatedNode.data.multiChoiceQuestion?.buttons ?? [];
+    const currentButtons = copyMcqButtons(
+      originalNode.data.multiChoiceQuestion?.buttons ?? defaultMultiChoiceQuestionButtons,
+    );
+    const newButtons = copyMcqButtons(updatedNode.data.multiChoiceQuestion?.buttons ?? []);
 
     const edges = instance.getEdges();
     const nodes = instance.getNodes();
@@ -362,7 +372,12 @@ const FlowElementsPopup: React.FC = () => {
       }));
 
     const updatedEdges = edges.map((edge) => {
-      if (!edge.label || !connectedEdges.some((ce) => ce.id === edge.id)) return edge;
+      if (
+        !edge.label ||
+        edge.source !== originalNode.id ||
+        !connectedEdges.some((ce) => ce.id === edge.id)
+      )
+        return edge;
       const rename = renamedButtons.find((r) => r.oldTitle === edge.label);
       if (rename) {
         return { ...edge, label: rename.newTitle };
@@ -387,10 +402,11 @@ const FlowElementsPopup: React.FC = () => {
     const buttonsNeedingEdges = addedButtons.filter((btn) => !existingButtonTitles.has(btn.title));
 
     const newEdges = buttonsNeedingEdges.map((button) => {
+      const ghostNodeId = `${originalNode.id}-ghost-${button.id}`;
       const newEdge: Edge = {
         id: `${originalNode.id}->${button.id}`,
         source: originalNode.id,
-        target: `ghost-${button.id}`,
+        target: ghostNodeId,
         type: 'step',
         animated: true,
         deletable: false,

--- a/GUI/src/components/FlowElementsPopup/index.tsx
+++ b/GUI/src/components/FlowElementsPopup/index.tsx
@@ -225,7 +225,7 @@ const FlowElementsPopup: React.FC = () => {
   };
 
   const prepareAssignForSaving = (updatedNode: Node<NodeDataProps>) => {
-    const flatEndpointVariables = endpointsVariables.map((endpoint) => endpoint.chips).flat();
+    const flatEndpointVariables = endpointsVariables.flatMap((endpoint) => endpoint.chips);    
     assignElements.forEach((element) => {
       const key = removeTrailingUnderscores(element.key);
       element.key = key;


### PR DESCRIPTION
This pull request improves how multi-choice question buttons are handled in the `FlowElementsPopup` component to avoid shared object references, which can lead to unintended side effects when editing or updating node data. The changes ensure that button arrays are copied rather than referenced directly, and also refine edge updating logic for better correctness when node connections change.

**Multi-choice question button handling:**

* Introduced a `copyMcqButtons` helper function to ensure that arrays of `MultiChoiceQuestionButton` objects are copied instead of referenced directly, preventing shared state issues between popup state and node data. This function is now used throughout the component wherever multi-choice buttons are set or updated. [[1]](diffhunk://#diff-3d4e91e7454c5b9f91b397967e95a3a6ade170666c7b3e59a56e38262bcfea52R88-R93) [[2]](diffhunk://#diff-3d4e91e7454c5b9f91b397967e95a3a6ade170666c7b3e59a56e38262bcfea52L104-R110) [[3]](diffhunk://#diff-3d4e91e7454c5b9f91b397967e95a3a6ade170666c7b3e59a56e38262bcfea52L139-R147) [[4]](diffhunk://#diff-3d4e91e7454c5b9f91b397967e95a3a6ade170666c7b3e59a56e38262bcfea52L166-R174) [[5]](diffhunk://#diff-3d4e91e7454c5b9f91b397967e95a3a6ade170666c7b3e59a56e38262bcfea52L190-R198) [[6]](diffhunk://#diff-3d4e91e7454c5b9f91b397967e95a3a6ade170666c7b3e59a56e38262bcfea52L342-R353)

**Edge update logic improvements:**

* Enhanced the logic for updating edge labels to ensure only edges originating from the current node are considered, reducing the risk of incorrectly relabeling unrelated edges.
* Adjusted the construction of new edge targets for added buttons to use a consistent ghost node ID format, improving clarity and preventing potential conflicts.