### PR TITLE
Fix for #946 and #947 bugs

### DIFF
--- a/DSL/Ruuter/services/POST/services/edit.yml
+++ b/DSL/Ruuter/services/POST/services/edit.yml
@@ -95,7 +95,17 @@ check_name_exists_result:
   switch:
     - condition: ${name_exists_res.response.body[0].nameExists}
       next: return_name_already_exists
-  next: delete_all_mcq_files   
+  next: delete_old_mcq_files
+
+delete_old_mcq_files:
+  call: http.post
+  args:
+    url: "[#SERVICE_DMAPPER]/file-manager/delete-all-that-starts-with"
+    body:
+      path: "[#RUUTER_SERVICES_PATH]/${type}/services/draft"
+      keyword: "${get_service_result.response.body[0].name}_"
+  result: deleteOldRes
+  next: delete_all_mcq_files
 
 delete_all_mcq_files:
   call: http.post
@@ -196,12 +206,27 @@ check_new_structure:
 use_new_structure:
   assign:
     new_structure: ${structure}
-  next: rename_dsl
+  next: check_rename_or_delete
 
 use_old_structure:
   assign:
     new_structure: ${old_structure.value}
+  next: check_rename_or_delete
+
+check_rename_or_delete:
+  switch:
+    - condition: ${content !== null && old_name !== name}
+      next: delete_old_main_file
   next: rename_dsl
+
+delete_old_main_file:
+  call: http.post
+  args:
+    url: "[#SERVICE_DMAPPER]/file-manager/delete"
+    body:
+      file_path: "[#RUUTER_SERVICES_PATH]/${type}/[#RUUTER_SERVICES_DIR_PATH]/${old_state}/${old_name}.tmp"
+  result: delete_old_main_result
+  next: service_edit
 
 rename_dsl:
   call: http.post

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -750,9 +750,12 @@ function handleMultiChoiceQuestion(
   childNode: Node<NodeDataProps> | undefined,
   serviceName: string,
 ) {
-  parentNode.data.multiChoiceQuestion?.buttons.forEach(
-    (b) => (b.payload = b.payload.replaceAll('/_mcq_', `/${serviceName}_mcq_`)),
-  );
+  const rootServiceName = serviceName.replace(/_mcq_\d+_\d+$/, '');
+  parentNode.data.multiChoiceQuestion?.buttons.forEach((b) => {
+
+    b.payload = b.payload.replace(/\/[^/]*_mcq_/, `/${rootServiceName}_mcq_`);
+
+  });
 
   return finishedFlow.set(parentStepName, {
     assign: {


### PR DESCRIPTION
#946 and #947 

This pull request introduces improvements to the service editing workflow, focusing on better handling of file cleanup during service renaming and enhancements to the multi-choice question payload logic. The main changes ensure that outdated files are properly deleted when a service is renamed and that payloads for multi-choice questions are generated more accurately.

**File management improvements during service edits:**

* Added a step to delete old MCQ-related files by calling the file manager service before proceeding to delete all MCQ files in the `edit.yml` workflow.
* Enhanced the structure update flow to check if the service name has changed, and if so, delete the old main file before proceeding with the edit.

**Multi-choice question payload logic:**

* Updated the `handleMultiChoiceQuestion` function to more robustly generate payloads for multi-choice question buttons by extracting the root service name, ensuring payloads are correctly formed after renaming.