### PR TITLE
Fix for html link issue #932

### DIFF
--- a/GUI/src/components/Flow/NodeTypes/StepNode.tsx
+++ b/GUI/src/components/Flow/NodeTypes/StepNode.tsx
@@ -8,7 +8,7 @@ import useServiceStore from 'store/new-services.store';
 import { StepType } from 'types';
 import { NodeDataProps } from 'types/service-flow';
 import { validateStep } from 'utils/flow-utils';
-import { decodeHtmlEntities } from 'utils/string-util';
+import { decodeHtmlEntities, ensureAbsoluteUrl } from 'utils/string-util';
 
 type StepNodeProps = {
   data: NodeDataProps;
@@ -30,6 +30,17 @@ const StepNode: FC<StepNodeProps> = ({ data }) => {
         a: ['href', 'target', 'rel'],
       },
       disallowedTagsMode: 'discard',
+      transformTags: {
+        a: (_tagName, attribs) => ({
+          tagName: 'a',
+          attribs: {
+            ...attribs,
+            href: ensureAbsoluteUrl(attribs.href ?? ''),
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          },
+        }),
+      },
     });
 
     return {

--- a/GUI/src/components/FormElements/FormRichText/index.tsx
+++ b/GUI/src/components/FormElements/FormRichText/index.tsx
@@ -65,7 +65,7 @@ const FormRichText: FC<FormRichTextProps> = ({ defaultValue, onChange, quill }) 
       preserveWhitespace
       onChange={(value) => {
         value = value === '<p><br></p>' ? '' : value;
-        const normalized = value.replace(
+        const normalized = value.replaceAll(
           /(<a\s[^>]*?)href=(["'])(?!https?:\/\/|\/\/)([^"'\s>]+)\2/gi,
           (_, pre, quote, href) => `${pre}href=${quote}https://${href}${quote}`,
         );

--- a/GUI/src/components/FormElements/FormRichText/index.tsx
+++ b/GUI/src/components/FormElements/FormRichText/index.tsx
@@ -1,6 +1,7 @@
 import { FC, Ref, useEffect } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
+import { ensureAbsoluteUrl } from 'utils/string-util';
 import './FormRichText.scss';
 
 type FormRichTextProps = {
@@ -25,6 +26,18 @@ const FormRichText: FC<FormRichTextProps> = ({ defaultValue, onChange, quill }) 
     const quillInstance = quill.current.getEditor();
     const editorElement = quillInstance.root;
 
+    const normalizeLinks = () => {
+      editorElement.querySelectorAll('a[href]').forEach((link) => {
+        const href = link.getAttribute('href') ?? '';
+        const normalized = ensureAbsoluteUrl(href);
+        if (normalized !== href) link.setAttribute('href', normalized);
+      });
+    };
+
+    // Normalize on mount (existing content) and on every content change
+    normalizeLinks();
+    quillInstance.on('text-change', normalizeLinks);
+
     const handleTabKey = (e: KeyboardEvent) => {
       if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
@@ -37,20 +50,27 @@ const FormRichText: FC<FormRichTextProps> = ({ defaultValue, onChange, quill }) 
     };
 
     editorElement.addEventListener('keydown', handleTabKey, true);
-    return () => editorElement.removeEventListener('keydown', handleTabKey, true);
+    return () => {
+      editorElement.removeEventListener('keydown', handleTabKey, true);
+      quillInstance.off('text-change', normalizeLinks);
+    };
   }, [quill]);
 
   return (
     <ReactQuill
       ref={quill}
       defaultValue={defaultValue}
-      onChange={(value) => {
-        value = value === '<p><br></p>' ? '' : value;
-        onChange(value.length === 0 ? null : value);
-      }}
       modules={modules}
       style={{ width: '100%' }}
       preserveWhitespace
+      onChange={(value) => {
+        value = value === '<p><br></p>' ? '' : value;
+        const normalized = value.replace(
+          /(<a\s[^>]*?)href=(["'])(?!https?:\/\/|\/\/)([^"'\s>]+)\2/gi,
+          (_, pre, quote, href) => `${pre}href=${quote}https://${href}${quote}`,
+        );
+        onChange(normalized.length === 0 ? null : normalized);
+      }}
     />
   );
 };

--- a/GUI/src/components/Markdowify/index.tsx
+++ b/GUI/src/components/Markdowify/index.tsx
@@ -1,6 +1,7 @@
 import Markdown from 'markdown-to-jsx';
 import React, { useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
+import { ensureAbsoluteUrl } from 'utils/string-util';
 
 interface MarkdownifyProps {
   message: string | undefined;
@@ -42,7 +43,7 @@ const LinkPreview: React.FC<{
 
   if (sanitizeLinks) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer">
+      <a href={ensureAbsoluteUrl(href)} target="_blank" rel="noopener noreferrer">
         {href}
       </a>
     );
@@ -50,7 +51,7 @@ const LinkPreview: React.FC<{
 
   if (!isValidImageUrl(href)) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer">
+      <a href={ensureAbsoluteUrl(href)} target="_blank" rel="noopener noreferrer">
         {children}
       </a>
     );
@@ -75,17 +76,15 @@ const hasSpecialFormat = (m: string) => m.includes('\n\n') && m.indexOf('.') > 0
 const htmlLinkToMarkdown = (value: string): string => {
   const tempDiv = document.createElement('div');
   tempDiv.innerHTML = value;
-  const links = tempDiv.querySelectorAll('a');
 
-  let result = value;
-  links.forEach((link) => {
-    const href = link.getAttribute('href') || '';
-    const text = link.textContent || href;
-    const markdown = href ? `[${text}](${href})` : text;
-    result = result.replace(link.outerHTML, markdown);
+  tempDiv.querySelectorAll('a').forEach((link) => {
+    const href = link.getAttribute('href') ?? '';
+    const text = link.textContent ?? href;
+    const replacement = href ? `[${text || href}](${ensureAbsoluteUrl(href)})` : text;
+    link.replaceWith(document.createTextNode(replacement));
   });
 
-  return result;
+  return tempDiv.innerHTML;
 };
 
 function formatMessage(message?: string): string {

--- a/GUI/src/utils/string-util.ts
+++ b/GUI/src/utils/string-util.ts
@@ -171,3 +171,10 @@ export function decodeHtmlEntities(value: string): string {
     .replaceAll('&#39;', "'")
     .replaceAll('&apos;', "'");
 }
+
+export const ensureAbsoluteUrl = (href: string): string => {
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//i.test(href) || href.startsWith('//')) {
+    return href;
+  }
+  return `https://${href}`;
+};

--- a/GUI/src/utils/string-util.ts
+++ b/GUI/src/utils/string-util.ts
@@ -31,7 +31,7 @@ export const fromSnakeCase = (value: string) => {
   const parts = value.split('_');
 
   // Check if the last part is a number
-  const lastPart = parts[parts.length - 1];
+  const lastPart = parts.at(-1) ?? '';
   const isLastPartNumber = /^\d+$/.test(lastPart);
 
   if (isLastPartNumber && parts.length > 1) {
@@ -173,7 +173,7 @@ export function decodeHtmlEntities(value: string): string {
 }
 
 export const ensureAbsoluteUrl = (href: string): string => {
-  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//i.test(href) || href.startsWith('//')) {
+  if (/^[a-z][a-z\d+\-.]*:\/\//i.test(href) || href.startsWith('//')) {
     return href;
   }
   return `https://${href}`;


### PR DESCRIPTION
#932 

Linked PR in chatbot : https://github.com/buerokratt/Buerokratt-Chatbot/pull/1843 

This pull request focuses on improving the safety and consistency of link handling across the application by ensuring that all URLs are absolute (i.e., include a protocol such as `https://`). The changes introduce a new utility function, `ensureAbsoluteUrl`, and apply it throughout the codebase to normalize links in user-generated content, markdown rendering, and the rich text editor. This helps prevent issues with malformed or potentially unsafe URLs.

**Link normalization and safety improvements:**

* Added a new utility function `ensureAbsoluteUrl` to `utils/string-util.ts`, which ensures that a given URL is absolute by prepending `https://` if necessary.
* Updated `FormRichText` component to normalize all anchor (`<a>`) tag `href` attributes to absolute URLs both on mount and on every content change, and also during the `onChange` handler. [[1]](diffhunk://#diff-03c07be932ad65f3d3671e8219eb050e9cd4142b2017c5f378568cad8d2db4ccR4) [[2]](diffhunk://#diff-03c07be932ad65f3d3671e8219eb050e9cd4142b2017c5f378568cad8d2db4ccR29-R40) [[3]](diffhunk://#diff-03c07be932ad65f3d3671e8219eb050e9cd4142b2017c5f378568cad8d2db4ccL40-R73)
* Modified the `StepNode` component to use `ensureAbsoluteUrl` when rendering links, ensuring that all links in step descriptions are absolute and safe. [[1]](diffhunk://#diff-ff5ea30b5c72c477cbdfa74aecd2a9dd8bb1f5671090a5a902a021259c208229L11-R11) [[2]](diffhunk://#diff-ff5ea30b5c72c477cbdfa74aecd2a9dd8bb1f5671090a5a902a021259c208229R33-R43)
* Enhanced the `Markdowify` component to use `ensureAbsoluteUrl` for all rendered links, both in the main markdown rendering and in the HTML-to-markdown conversion utility. [[1]](diffhunk://#diff-f1565bb40ab5a034609f5caee2e77dadd5b590bcca44ab415e830cbcdf1ad91cR4) [[2]](diffhunk://#diff-f1565bb40ab5a034609f5caee2e77dadd5b590bcca44ab415e830cbcdf1ad91cL45-R54) [[3]](diffhunk://#diff-f1565bb40ab5a034609f5caee2e77dadd5b590bcca44ab415e830cbcdf1ad91cL78-R87)