### PR TITLE
Repair imported MCQ payload references on save

### DIFF
--- a/DSL/Ruuter/services/POST/services/import-services.yml
+++ b/DSL/Ruuter/services/POST/services/import-services.yml
@@ -35,6 +35,8 @@ assign_imported_names:
     imported_names: ${import_names_res.response.body[0].names.split(",")}
     services: "$=services.map((s, i) => ({ ...s, fileName: imported_names[i] }))="
     file_names: ${services.map(s => s.fileName)}
+    all_sub_services: "$=services.flatMap(s => (s.subServices ?? []).map(sub => ({ fileName: s.fileName + sub.suffix, content: sub.content })))="
+    all_file_names: "$=[...file_names, ...all_sub_services.map(s => s.fileName)]="
 
 insert_services:
   call: http.post
@@ -50,12 +52,12 @@ convert_json_content_to_yml:
   args:
     url: "[#SERVICE_DMAPPER]/conversion/json_to_yaml_data_multiple"
     body:
-      data: ${services.map(s => s.content)}
+      data: "$=[...services.map(s => s.content), ...all_sub_services.map(s => s.content)]="
   result: ymls_res
 
 prepare_files:
   assign:
-    file_paths: "$=file_names.map(name => `[#RUUTER_SERVICES_POST_PATH]/draft/${name}.tmp`)="
+    file_paths: "$=all_file_names.map(name => `[#RUUTER_SERVICES_POST_PATH]/draft/${name}.tmp`)="
     yaml_contents: ${ymls_res.response.body.yamls}
 
 add_dsls:
@@ -68,4 +70,5 @@ add_dsls:
   result: add_dsls_res
 
 return_result:
+  reloadDsl: true
   return: "Services imported successfully"

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -23,6 +23,114 @@ import {
 
 import api from '../services/api-dev';
 
+/**
+ * Normalises MCQ button payloads on all MultiChoiceQuestion nodes.
+ *
+ * Imported services may reference the wrong service name (the original export
+ * name) and stale button indices.  This function rebuilds every button's
+ * payload so it matches:
+ *   #service, /<type>/services/active/<serviceName>_mcq_<nodeId>_<buttonIndex>
+ *
+ * Safe to call on any flow: nodes that have no MCQ data are left untouched.
+ */
+export function normalizeMcqPayloads(nodes: Node<NodeDataProps>[], serviceName: string): Node<NodeDataProps>[] {
+  return nodes.map((node) => {
+    if (node.data?.stepType !== StepType.MultiChoiceQuestion) return node;
+
+    const buttons = node.data.multiChoiceQuestion?.buttons;
+    if (!Array.isArray(buttons) || buttons.length === 0) return node;
+
+    const mcqNodeId = getLastDigits(toSnakeCase(node.data.label ?? ''));
+
+    const normalizedButtons = buttons.map((btn, idx) => {
+      // Only rewrite payloads that already follow the MCQ payload convention.
+      // Payloads that don't match are left unchanged to avoid corrupting custom data.
+      const mcqPayloadPattern = /^(#service,\s*\/[^/]+\/services\/active\/)([^/]+_mcq_\d+_)(\d+)$/;
+      const match = btn.payload?.match(mcqPayloadPattern);
+      if (!match) return btn;
+
+      const prefix = match[1]; // e.g. "#service, /POST/services/active/"
+      return {
+        ...btn,
+        payload: `${prefix}${serviceName}_mcq_${mcqNodeId}_${idx}`,
+      };
+    });
+
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        multiChoiceQuestion: {
+          ...node.data.multiChoiceQuestion!,
+          buttons: normalizedButtons,
+        },
+      },
+    };
+  });
+}
+
+/**
+ * Builds YAML content for the main service and all MCQ branch sub-services.
+ *
+ * Sub-services are embedded inside the returned object so that each JSON file
+ * is self-contained when sent to the import-services endpoint. The server
+ * resolves the final main service name (adding a timestamp on conflict) and
+ * then prepends that resolved name to each sub-service suffix.
+ */
+export function buildAllServiceContents(
+  rawNodes: Node<NodeDataProps>[],
+  edges: Edge[],
+  name: string,
+  description: string = '',
+): {
+  name: string;
+  content: any;
+  flowData: string;
+  subServices: Array<{ suffix: string; content: any }>;
+} {
+  const nodes = normalizeMcqPayloads(rawNodes, name);
+  const mcqNodes = nodes.filter((n) => n.data?.stepType === StepType.MultiChoiceQuestion);
+  const fullFlowData = JSON.stringify({ nodes: rawNodes, edges });
+
+  // Main service – truncated at the first MCQ node (same as saveFlow)
+  const mainNodes =
+    mcqNodes.length > 0
+      ? nodes.slice(0, nodes.findIndex((n) => n.data?.stepType === StepType.MultiChoiceQuestion) + 1)
+      : nodes;
+
+  const subServices: Array<{ suffix: string; content: any }> = [];
+
+  for (const mcqNode of mcqNodes) {
+    const mcqEdges = edges.filter((e) => e.source === mcqNode.id);
+    for (const [edgeIdx, edge] of mcqEdges.entries()) {
+      const nextNode = nodes.find((n) => n.id === edge.target);
+      if (!nextNode) continue;
+
+      const foundIndex =
+        mcqNode.data?.multiChoiceQuestion?.buttons.findIndex((b: any) => b.title === edge.label) ?? -1;
+      const buttonIndex = foundIndex !== -1 ? foundIndex : edgeIdx;
+      const mcqNodeId = getLastDigits(toSnakeCase(mcqNode.data.label ?? ''));
+      const suffix = `_mcq_${mcqNodeId}_${buttonIndex}`;
+      const subServiceName = `${name}${suffix}`;
+
+      const branchNodes = getBranchNodes(nodes, edges, nextNode);
+      const branchEdges = edges.filter((e) => branchNodes.some((n) => n.id === e.source || n.id === e.target));
+
+      subServices.push({
+        suffix,
+        content: getYamlContent(branchNodes, branchEdges, subServiceName, description, false),
+      });
+    }
+  }
+
+  return {
+    name,
+    content: getYamlContent(mainNodes, edges, name, description, false),
+    flowData: fullFlowData,
+    subServices,
+  };
+}
+
 export async function saveEndpoints(endpoints: EndpointData[], onSuccess?: () => void, onError?: (e: any) => void) {
   const tasks: Promise<any>[] = [];
   const serviceId = useServiceStore.getState().serviceId;
@@ -171,7 +279,7 @@ const buildConditionString = (group: any, assignedVariableNames: Set<string>): s
 export const saveFlow = async ({
   name,
   edges,
-  nodes,
+  nodes: rawNodes,
   onSuccess,
   onError,
   description,
@@ -185,6 +293,7 @@ export const saveFlow = async ({
   showError = true,
 }: SaveFlowConfig) => {
   try {
+    const nodes = normalizeMcqPayloads(rawNodes, name);
     let yamlContent = getYamlContent(nodes, edges, name, description, showError);
 
     const mcqNodes = nodes.filter((node) => node.data?.stepType === StepType.MultiChoiceQuestion);
@@ -220,11 +329,12 @@ export const saveFlow = async ({
     for (const mcqNode of mcqNodes) {
       const mcqEdges = edges.filter((edge) => edge.source === mcqNode.id);
 
-      for (const edge of mcqEdges) {
+      for (const [edgeIdx, edge] of mcqEdges.entries()) {
         const nextNode = nodes.find((n) => n.id === edge.target);
         if (!nextNode) continue;
 
-        const buttonIndex = mcqNode?.data?.multiChoiceQuestion?.buttons.findIndex((e: any) => e.title === edge.label);
+        const foundIndex = mcqNode?.data?.multiChoiceQuestion?.buttons.findIndex((e: any) => e.title === edge.label);
+        const buttonIndex = foundIndex !== -1 ? foundIndex : edgeIdx;
         const mcqNodeId = getLastDigits(toSnakeCase(mcqNode.data.label ?? ''));
         const serviceName = `${name}_mcq_${mcqNodeId}_${buttonIndex}`;
         const branchNodes = getBranchNodes(nodes, edges, nextNode);

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -46,7 +46,7 @@ export function normalizeMcqPayloads(nodes: Node<NodeDataProps>[], serviceName: 
       // Only rewrite payloads that already follow the MCQ payload convention.
       // Payloads that don't match are left unchanged to avoid corrupting custom data.
       const mcqPayloadPattern = /^(#service,\s*\/[^/]+\/services\/active\/)([^/]+_mcq_\d+_)(\d+)$/;
-      const match = btn.payload?.match(mcqPayloadPattern);
+      const match = mcqPayloadPattern.exec(btn.payload ?? '');
       if (!match) return btn;
 
       const prefix = match[1]; // e.g. "#service, /POST/services/active/"
@@ -87,10 +87,10 @@ export function normalizeEdgeLabels(edges: Edge[], nodes: Node<NodeDataProps>[])
 
     mcqEdges.forEach((edge) => {
       const idx = buttons.findIndex((b: any) => b.title === edge.label);
-      if (idx !== -1) {
-        claimedIndices.add(idx);
-      } else {
+      if (idx === -1) {
         unclaimedEdges.push(edge);
+      } else {
+        claimedIndices.add(idx);
       }
     });
 
@@ -146,7 +146,7 @@ export function buildAllServiceContents(
       if (!nextNode) continue;
 
       const foundIndex = mcqNode.data?.multiChoiceQuestion?.buttons.findIndex((b: any) => b.title === edge.label) ?? -1;
-      const buttonIndex = foundIndex !== -1 ? foundIndex : edgeIdx;
+      const buttonIndex = foundIndex === -1 ? edgeIdx : foundIndex;
       const mcqNodeId = getLastDigits(toSnakeCase(mcqNode.data.label ?? ''));
       const suffix = `_mcq_${mcqNodeId}_${buttonIndex}`;
       const subServiceName = `${name}${suffix}`;
@@ -373,7 +373,7 @@ export const saveFlow = async ({
         if (!nextNode) continue;
 
         const foundIndex = mcqNode?.data?.multiChoiceQuestion?.buttons.findIndex((e: any) => e.title === edge.label);
-        const buttonIndex = foundIndex !== -1 ? foundIndex : edgeIdx;
+        const buttonIndex = foundIndex === -1 ? edgeIdx : foundIndex;
         const mcqNodeId = getLastDigits(toSnakeCase(mcqNode.data.label ?? ''));
         const serviceName = `${name}_mcq_${mcqNodeId}_${buttonIndex}`;
         const branchNodes = getBranchNodes(nodes, edges, nextNode);

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -145,8 +145,7 @@ export function buildAllServiceContents(
       const nextNode = nodes.find((n) => n.id === edge.target);
       if (!nextNode) continue;
 
-      const foundIndex =
-        mcqNode.data?.multiChoiceQuestion?.buttons.findIndex((b: any) => b.title === edge.label) ?? -1;
+      const foundIndex = mcqNode.data?.multiChoiceQuestion?.buttons.findIndex((b: any) => b.title === edge.label) ?? -1;
       const buttonIndex = foundIndex !== -1 ? foundIndex : edgeIdx;
       const mcqNodeId = getLastDigits(toSnakeCase(mcqNode.data.label ?? ''));
       const suffix = `_mcq_${mcqNodeId}_${buttonIndex}`;

--- a/GUI/src/services/service-builder.ts
+++ b/GUI/src/services/service-builder.ts
@@ -69,6 +69,45 @@ export function normalizeMcqPayloads(nodes: Node<NodeDataProps>[], serviceName: 
   });
 }
 
+export function normalizeEdgeLabels(edges: Edge[], nodes: Node<NodeDataProps>[]): Edge[] {
+  const mcqNodes = nodes.filter((n) => n.data?.stepType === StepType.MultiChoiceQuestion);
+  if (mcqNodes.length === 0) return edges;
+
+  const edgeMap = new Map(edges.map((e) => [e.id, { ...e }]));
+
+  for (const mcqNode of mcqNodes) {
+    const buttons = mcqNode.data?.multiChoiceQuestion?.buttons;
+    if (!Array.isArray(buttons)) continue;
+
+    const mcqEdges = edges.filter((e) => e.source === mcqNode.id);
+
+    // Find button indices already claimed by correctly-labeled edges
+    const claimedIndices = new Set<number>();
+    const unclaimedEdges: Edge[] = [];
+
+    mcqEdges.forEach((edge) => {
+      const idx = buttons.findIndex((b: any) => b.title === edge.label);
+      if (idx !== -1) {
+        claimedIndices.add(idx);
+      } else {
+        unclaimedEdges.push(edge);
+      }
+    });
+
+    // Assign remaining button titles only to edges with broken/missing labels
+    const unclaimedButtonIndices = buttons.map((_, i) => i).filter((i) => !claimedIndices.has(i));
+
+    unclaimedEdges.forEach((edge, i) => {
+      if (i < unclaimedButtonIndices.length) {
+        const copy = edgeMap.get(edge.id);
+        if (copy) copy.label = buttons[unclaimedButtonIndices[i]].title;
+      }
+    });
+  }
+
+  return edges.map((e) => edgeMap.get(e.id) ?? e);
+}
+
 /**
  * Builds YAML content for the main service and all MCQ branch sub-services.
  *
@@ -278,7 +317,7 @@ const buildConditionString = (group: any, assignedVariableNames: Set<string>): s
 
 export const saveFlow = async ({
   name,
-  edges,
+  edges: rawEdges,
   nodes: rawNodes,
   onSuccess,
   onError,
@@ -294,6 +333,7 @@ export const saveFlow = async ({
 }: SaveFlowConfig) => {
   try {
     const nodes = normalizeMcqPayloads(rawNodes, name);
+    const edges = normalizeEdgeLabels(rawEdges, nodes);
     let yamlContent = getYamlContent(nodes, edges, name, description, showError);
 
     const mcqNodes = nodes.filter((node) => node.data?.stepType === StepType.MultiChoiceQuestion);

--- a/GUI/src/utils/service-import.ts
+++ b/GUI/src/utils/service-import.ts
@@ -14,13 +14,23 @@ const isValidFlowData = (data: any): data is FlowData =>
 const handleImportServices = async (
   event: ChangeEvent<HTMLInputElement>,
 ): Promise<{
-  validFiles: Array<{ fileName: string; flowData: string; content: any; subServices: Array<{ suffix: string; content: any }> }>;
+  validFiles: Array<{
+    fileName: string;
+    flowData: string;
+    content: any;
+    subServices: Array<{ suffix: string; content: any }>;
+  }>;
   corruptedFiles: string[];
 }> => {
   const files = event.target.files;
   if (!files) return { validFiles: [], corruptedFiles: [] };
 
-  const validFiles: Array<{ fileName: string; flowData: string; content: any; subServices: Array<{ suffix: string; content: any }> }> = [];
+  const validFiles: Array<{
+    fileName: string;
+    flowData: string;
+    content: any;
+    subServices: Array<{ suffix: string; content: any }>;
+  }> = [];
   const corruptedFiles: string[] = [];
 
   const fileProcessingPromises = Array.from(files).map(async (file) => {

--- a/GUI/src/utils/service-import.ts
+++ b/GUI/src/utils/service-import.ts
@@ -3,7 +3,7 @@ import { t } from 'i18next';
 import { ChangeEvent } from 'react';
 import { importMultipleServices } from 'resources/api-constants';
 import api from 'services/api';
-import { getYamlContent } from 'services/service-builder';
+import { buildAllServiceContents } from 'services/service-builder';
 import useServiceListStore from 'store/services.store';
 import useToastStore from 'store/toasts.store';
 import { FlowData } from 'types/service-flow';
@@ -14,13 +14,13 @@ const isValidFlowData = (data: any): data is FlowData =>
 const handleImportServices = async (
   event: ChangeEvent<HTMLInputElement>,
 ): Promise<{
-  validFiles: Array<{ fileName: string; flowData: string; content: any }>;
+  validFiles: Array<{ fileName: string; flowData: string; content: any; subServices: Array<{ suffix: string; content: any }> }>;
   corruptedFiles: string[];
 }> => {
   const files = event.target.files;
   if (!files) return { validFiles: [], corruptedFiles: [] };
 
-  const validFiles: Array<{ fileName: string; flowData: string; content: any }> = [];
+  const validFiles: Array<{ fileName: string; flowData: string; content: any; subServices: Array<{ suffix: string; content: any }> }> = [];
   const corruptedFiles: string[] = [];
 
   const fileProcessingPromises = Array.from(files).map(async (file) => {
@@ -33,10 +33,13 @@ const handleImportServices = async (
         throw new Error('Invalid flow data structure');
       }
 
+      const result = buildAllServiceContents(flowData.nodes, flowData.edges, name);
+
       validFiles.push({
-        fileName: name,
-        flowData: JSON.stringify({ nodes: flowData.nodes, edges: flowData.edges }),
-        content: getYamlContent(flowData.nodes, flowData.edges, name, '', false),
+        fileName: result.name,
+        flowData: result.flowData,
+        content: result.content,
+        subServices: result.subServices,
       });
     } catch (error) {
       corruptedFiles.push(name);

--- a/GUI/src/utils/service-import.ts
+++ b/GUI/src/utils/service-import.ts
@@ -34,7 +34,8 @@ const handleImportServices = async (
   const corruptedFiles: string[] = [];
 
   const fileProcessingPromises = Array.from(files).map(async (file) => {
-    const name = file.name.replaceAll(/\s+/g, '_').replace(/\.[^/.]+$/, '');
+    const rawName = file.name.replaceAll(/\s+/g, '_').replace(/\.[^/.]+$/, '');
+    const name = rawName.replace(/(_\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2})+$/, '');
     try {
       const content = await file.text();
       const flowData = JSON.parse(content) as FlowData;


### PR DESCRIPTION
This pull request introduces improvements to the service import/export flow, especially around handling MultiChoiceQuestion (MCQ) nodes and their branching logic. The main changes include normalizing MCQ payloads and edge labels, supporting the export and import of MCQ branch sub-services, and updating the YAML and file handling logic to accommodate these changes.

**Improvements to MCQ Node Handling and Branching:**

- Added `normalizeMcqPayloads` and `normalizeEdgeLabels` functions in `service-builder.ts` to ensure all MCQ button payloads and edge labels are consistent and correct during both export and import.
- Updated the flow saving logic in `saveFlow` to use these normalization functions, ensuring that MCQ-related data is always valid before saving.

**Support for MCQ Branch Sub-services:**

- Introduced `buildAllServiceContents` in `service-builder.ts`, which generates YAML content for both the main service and all MCQ branch sub-services, encapsulating all related flows for import/export.
- Updated the import logic in `service-import.ts` to use `buildAllServiceContents`, so imported files can include both main and sub-service definitions. The `validFiles` structure now includes a `subServices` array. [[1]](diffhunk://#diff-0e4996b93b50bfd81103c11dd3808e306c38f13be85e1dcacca92171655bc231L6-R6) [[2]](diffhunk://#diff-0e4996b93b50bfd81103c11dd3808e306c38f13be85e1dcacca92171655bc231L17-R23) [[3]](diffhunk://#diff-0e4996b93b50bfd81103c11dd3808e306c38f13be85e1dcacca92171655bc231R36-R42)

**YAML and File Handling Updates:**

- Modified the YAML pipeline in `import-services.yml` to handle sub-services: collects all sub-service contents, generates their YAML, and includes them in the file upload and conversion steps. [[1]](diffhunk://#diff-3ddd7d4fd4a031451d4b58a978512413fc3b14192d8a3bc04a4981df6cfbe22aR38-R39) [[2]](diffhunk://#diff-3ddd7d4fd4a031451d4b58a978512413fc3b14192d8a3bc04a4981df6cfbe22aL53-R60)
- Ensured that all file names (main and sub-services) are tracked and processed during import. [[1]](diffhunk://#diff-3ddd7d4fd4a031451d4b58a978512413fc3b14192d8a3bc04a4981df6cfbe22aR38-R39) [[2]](diffhunk://#diff-3ddd7d4fd4a031451d4b58a978512413fc3b14192d8a3bc04a4981df6cfbe22aL53-R60)

**Miscellaneous:**

- Added a `reloadDsl: true` return value to signal that the DSL should be reloaded after importing services.
