### PR TITLE
Path param support for endpoints

### DIFF
--- a/DSL/Ruuter/services/POST/services/requests/explain.yml
+++ b/DSL/Ruuter/services/POST/services/requests/explain.yml
@@ -49,12 +49,43 @@ request_explain_get:
     headers: $! current_request.headers !
     query: $! current_request.params !
   result: res
+  next: check_get_redirect
+
+check_get_redirect:
+  switch:
+    - condition: ${res.response.statusCodeValue == 301 || res.response.statusCodeValue == 302}
+      next: retry_get_with_slash
+  next: assign_result
+
+retry_get_with_slash:
+  call: http.get
+  args:
+    url: ${current_request.url + '/'}
+    headers: $! current_request.headers !
+    query: $! current_request.params !
+  result: res
   next: assign_result
 
 request_explain_post:
   call: http.post
   args:
     url: ${current_request.url}
+    headers: $! current_request.headers !
+    query: $! current_request.params !
+    body: $! current_request.body !
+  result: res
+  next: check_post_redirect
+
+check_post_redirect:
+  switch:
+    - condition: ${res.response.statusCodeValue == 301 || res.response.statusCodeValue == 302}
+      next: retry_post_with_slash
+  next: assign_result
+
+retry_post_with_slash:
+  call: http.post
+  args:
+    url: ${current_request.url + '/'}
     headers: $! current_request.headers !
     query: $! current_request.params !
     body: $! current_request.body !

--- a/GUI/src/components/ApiEndpointCard/Endpoints/Custom/index.tsx
+++ b/GUI/src/components/ApiEndpointCard/Endpoints/Custom/index.tsx
@@ -96,9 +96,11 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
     // endpoints loaded from the DB (where paramType may not be persisted) work correctly.
     const allParams = def.params?.variables ?? [];
     const urlPathPart = (def.url ?? '').split('?')[0];
-    const pathPlaceholderNames = [...urlPathPart.matchAll(/(?<!\$)\{([^}]+)\}/g)].map((m) => m[1]);
-    const pathParams = allParams.filter((v) => pathPlaceholderNames.includes(v.name));
-    const queryParams = allParams.filter((v) => !pathPlaceholderNames.includes(v.name));
+    const pathPlaceholderNames = new Set(
+      [...urlPathPart.matchAll(/(?<!\$)\{(\w+)\}/g)].map((m) => m[1]),
+    );
+    const pathParams = allParams.filter((v) => pathPlaceholderNames.has(v.name));
+    const queryParams = allParams.filter((v) => !pathPlaceholderNames.has(v.name));
 
     // Validate path params have values
     for (const param of pathParams) {
@@ -121,14 +123,14 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
     // Replace {name} placeholders in the URL path
     let testUrl = def.url ?? '';
     for (const param of pathParams) {
-      testUrl = testUrl.split(`{${param.name}}`).join(encodeURIComponent(param.value!));
+      testUrl = testUrl.split(`{${param.name}}`).join(encodeURIComponent(param.value ?? ''));
     }
 
     // Strip query string — query params are sent separately via the params map
     const testUrlBase = testUrl.includes('?') ? testUrl.split('?')[0] : testUrl;
 
     // Check for any remaining unresolved {name} in the path (excluding ${var} runtime vars)
-    const unresolvedRegex = /(?<!\$)\{([^}]+)\}/;
+    const unresolvedRegex = /(?<!\$)\{(\w+)\}/;
     const remaining = unresolvedRegex.exec(testUrlBase);
     if (remaining) {
       useToastStore.getState().error({ title: t('newService.endpoint.unresolvedPlaceholder', { name: remaining[1] }) });
@@ -363,7 +365,7 @@ function parseURLWithPlaceholders(url: string): {
 
     // Detect {name} placeholders in the path portion
     const pathParams: string[] = [];
-    const pathPlaceholderRegex = /\{([^}]+)\}/g;
+    const pathPlaceholderRegex = /\{(\w+)\}/g;
     let match;
     while ((match = pathPlaceholderRegex.exec(pathPart)) !== null) {
       if (!pathParams.includes(match[1])) {

--- a/GUI/src/components/ApiEndpointCard/Endpoints/Custom/index.tsx
+++ b/GUI/src/components/ApiEndpointCard/Endpoints/Custom/index.tsx
@@ -89,14 +89,63 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
   const handleJsonRequestClick = () => {
     setIsTesting(true);
     const def = endpoint.definitions[0];
+
+    // Build the test URL by resolving {param} placeholders.
+    // PATH params must have values; any remaining unresolved {name} blocks the test.
+    // Derive path param names directly from {name} placeholders in the URL path so that
+    // endpoints loaded from the DB (where paramType may not be persisted) work correctly.
+    const allParams = def.params?.variables ?? [];
+    const urlPathPart = (def.url ?? '').split('?')[0];
+    const pathPlaceholderNames = [...urlPathPart.matchAll(/(?<!\$)\{([^}]+)\}/g)].map((m) => m[1]);
+    const pathParams = allParams.filter((v) => pathPlaceholderNames.includes(v.name));
+    const queryParams = allParams.filter((v) => !pathPlaceholderNames.includes(v.name));
+
+    // Validate path params have values
+    for (const param of pathParams) {
+      if (!param.value?.trim()) {
+        useToastStore.getState().error({ title: t('newService.endpoint.missingPathParam', { name: param.name }) });
+        setIsTesting(false);
+        return;
+      }
+    }
+
+    // Validate named query params have values (dynamic placeholders must be filled)
+    for (const param of queryParams) {
+      if (param.name && !param.value?.trim()) {
+        useToastStore.getState().error({ title: t('newService.endpoint.missingPathParam', { name: param.name }) });
+        setIsTesting(false);
+        return;
+      }
+    }
+
+    // Replace {name} placeholders in the URL path
+    let testUrl = def.url ?? '';
+    for (const param of pathParams) {
+      testUrl = testUrl.split(`{${param.name}}`).join(encodeURIComponent(param.value!));
+    }
+
+    // Strip query string — query params are sent separately via the params map
+    const testUrlBase = testUrl.includes('?') ? testUrl.split('?')[0] : testUrl;
+
+    // Check for any remaining unresolved {name} in the path (excluding ${var} runtime vars)
+    const unresolvedRegex = /(?<!\$)\{([^}]+)\}/;
+    const remaining = unresolvedRegex.exec(testUrlBase);
+    if (remaining) {
+      useToastStore.getState().error({ title: t('newService.endpoint.unresolvedPlaceholder', { name: remaining[1] }) });
+      setIsTesting(false);
+      return;
+    }
+
+    const queryOnlyParams = def.params ? { ...def.params, variables: queryParams } : undefined;
+
     const request = {
-      url: def.url,
+      url: testUrlBase,
       method: def.methodType,
       headers: extractMapValues(def.headers) as Record<string, string>,
-      params: extractMapValues(def.params) as Record<string, string>,
+      params: extractMapValues(queryOnlyParams) as Record<string, string>,
       body: getEndpointBody(def),
     };
-    generateJsonRequest(def)
+    generateJsonRequest({ ...def, url: testUrlBase, params: queryOnlyParams })
       .then((content) => {
         const schema = JSON.stringify(content, undefined, 4);
         setResponseContent(schema);
@@ -161,10 +210,26 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
               label=""
               defaultValue={endpoint.definitions[0]?.url ?? ''}
               onChange={(event) => {
-                const parsedUrl = parseURL(event.target.value);
+                const parsedUrl = parseURLWithPlaceholders(event.target.value);
                 endpoint.definitions[0].url = parsedUrl.url;
 
+                const existingVars = endpoint.definitions[0].params?.variables ?? [];
                 const parameters: EndpointVariableData[] = [];
+
+                // Add path params first (preserve existing values entered by the user)
+                parsedUrl.pathParams.forEach((name) => {
+                  const existing = existingVars.find((v) => v.name === name && v.paramType === 'path');
+                  parameters.push({
+                    id: existing?.id ?? uuid(),
+                    name,
+                    type: 'custom',
+                    required: false,
+                    value: existing?.value ?? '',
+                    paramType: 'path',
+                  });
+                });
+
+                // Add query params
                 Object.keys(parsedUrl.params).forEach((key) => {
                   parameters.push({
                     id: uuid(),
@@ -173,6 +238,7 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
                     required: false,
                     value: parsedUrl.params[key],
                     operator: (parsedUrl.operators[key] as RequestOperator) || '=',
+                    paramType: 'query',
                   });
                 });
 
@@ -197,18 +263,34 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
         setRequestTab={setRequestTab}
         onMandatoryViolationChange={onMandatoryViolationChange}
         onParametersChange={(parameters) => {
-          const url = new URL(endpoint.definitions[0].url ?? '');
-          const baseUrl = `${url.origin}${url.pathname}`;
+          // Preserve the path template (including {name} placeholders) from stored URL.
+          // Use string split instead of URL constructor to avoid encoding {braces}.
+          const storedUrl = endpoint.definitions[0].url ?? '';
+          let pathTemplate = storedUrl.includes('?') ? storedUrl.split('?')[0] : storedUrl;
 
+          // When a path param is renamed, update the {oldName} placeholder in the URL path.
+          const oldPathParams = endpoint.definitions[0].params?.variables?.filter((p) => p.paramType === 'path') ?? [];
+          const newPathParams = parameters.filter((p) => p.paramType === 'path');
+          for (const newParam of newPathParams) {
+            const oldParam = oldPathParams.find((p) => p.id === newParam.id);
+            if (oldParam && oldParam.name !== newParam.name && newParam.name) {
+              pathTemplate = pathTemplate.split(`{${oldParam.name}}`).join(`{${newParam.name}}`);
+            }
+          }
+
+          // Rebuild query string from non-path params.
+          // Empty values restore the {paramName} placeholder so the URL stays as a template.
+          // Renaming a query param key here updates the corresponding key in the URL.
           const queryString = parameters
-            .filter((param) => param.value && param.name)
+            .filter((param) => param.paramType !== 'path' && param.name)
             .map((param) => {
-              const operator = param.operator ? param.operator : '=';
-              return `${param.name}${operator}${encodeURIComponent(param.value ?? '')}`;
+              const operator = param.operator ?? '=';
+              const val = param.value?.trim() ? encodeURIComponent(param.value) : `{${param.name}}`;
+              return `${param.name}${operator}${val}`;
             })
             .join('&');
 
-          endpoint.definitions[0].url = queryString ? `${baseUrl}?${queryString}` : baseUrl;
+          endpoint.definitions[0].url = queryString ? `${pathTemplate}?${queryString}` : pathTemplate;
           endpoint.definitions[0].params = {
             variables: parameters,
             rawData: {},
@@ -270,19 +352,37 @@ const EndpointCustom: React.FC<EndpointCustomProps> = ({
   );
 };
 
-function parseURL(url: string) {
+function parseURLWithPlaceholders(url: string): {
+  url: string;
+  pathParams: string[];
+  params: Record<string, string>;
+  operators: Record<string, string>;
+} {
   try {
-    const queryString = url.split('?')[1] ?? '';
-    const params: Record<string, any> = {};
-    const operators: Record<string, string> = {};
+    const [pathPart, queryPart = ''] = url.split('?');
 
-    queryString
+    // Detect {name} placeholders in the path portion
+    const pathParams: string[] = [];
+    const pathPlaceholderRegex = /\{([^}]+)\}/g;
+    let match;
+    while ((match = pathPlaceholderRegex.exec(pathPart)) !== null) {
+      if (!pathParams.includes(match[1])) {
+        pathParams.push(match[1]);
+      }
+    }
+
+    // Parse query params
+    const params: Record<string, string> = {};
+    const operators: Record<string, string> = {};
+    queryPart
       .split('&')
       .filter(Boolean)
       .forEach((segment) => {
         const { index, token } = findOperators(segment);
         const name = decodeURIComponent(index === -1 ? segment : segment.slice(0, index));
-        const value = decodeURIComponent(index === -1 ? '' : segment.slice(index + token.length));
+        const rawValue = decodeURIComponent(index === -1 ? '' : segment.slice(index + token.length));
+        // If the value is itself a {placeholder}, treat it as empty (dynamic param — user fills in Params tab)
+        const value = /^\{[^}]+\}$/.test(rawValue) ? '' : rawValue;
         const operator = index === -1 ? '=' : token;
         if (name) {
           params[name] = value;
@@ -290,10 +390,10 @@ function parseURL(url: string) {
         }
       });
 
-    return { url, params, operators };
+    return { url, pathParams, params, operators };
   } catch (e) {
     console.error('Invalid URL format:', e);
-    return { url, params: {}, operators: {} };
+    return { url, pathParams: [], params: {}, operators: {} };
   }
 }
 

--- a/GUI/src/components/ApiEndpointCard/Endpoints/RequestVariables/VariableCell/index.tsx
+++ b/GUI/src/components/ApiEndpointCard/Endpoints/RequestVariables/VariableCell/index.tsx
@@ -36,11 +36,16 @@ const VariableCell: React.FC<VariableCellProps> = ({ row, updateRowVariable, var
       placeholder={t('newService.endpoint.variable') + '..'}
     />
   ) : (
-    <p style={{ paddingLeft: 40 * row.original.nestedLevel }}>
-      {row.original.variable}
-      {row.original.type && `, (${row.original.type})`}
-      {row.original.description && `, (${row.original.description})`}
-    </p>
+    <div style={{ paddingLeft: 40 * row.original.nestedLevel }}>
+      <FormInput
+        style={{ borderRadius: '4px', backgroundColor: '#f5f5f7', cursor: 'default' }}
+        name={`endpoint-variable-readonly-${row.id}`}
+        label=""
+        value={row.original.variable ?? ''}
+        readOnly
+        onChange={() => {}}
+      />
+    </div>
   );
 };
 

--- a/GUI/src/components/ApiEndpointCard/Endpoints/RequestVariables/index.tsx
+++ b/GUI/src/components/ApiEndpointCard/Endpoints/RequestVariables/index.tsx
@@ -77,6 +77,7 @@ const RequestVariables: React.FC<RequestVariablesProps> = ({
       description: data.description,
       arrayType: data.arrayType,
       nestedLevel,
+      paramType: data.paramType,
     };
   };
 
@@ -199,6 +200,7 @@ const RequestVariables: React.FC<RequestVariablesProps> = ({
               value: row.value!,
               description: row.description,
               operator: row.operator as RequestOperator,
+              paramType: row.paramType,
             })) ?? [];
         onParametersChange(params);
         // All named params need description; mandatory params also need a value
@@ -253,6 +255,7 @@ const RequestVariables: React.FC<RequestVariablesProps> = ({
         value: row.value,
         description: row.description,
         operator: requestTab.tab === EndpointTab.Params ? (row.operator as RequestOperator) || '=' : undefined,
+        paramType: row.paramType,
       };
       variables.push(newVariable);
     });
@@ -317,7 +320,11 @@ const RequestVariables: React.FC<RequestVariablesProps> = ({
 
     const variables: EndpointVariableData[] = [];
     newData.forEach((row) => {
-      if (!row.value || !row.variable) return;
+      // Always include path params (value may be empty while user fills it in);
+      // for regular params, require both name and value.
+      const isPathParam = row.paramType === 'path';
+      if (!isPathParam && (!row.value || !row.variable)) return;
+      if (isPathParam && !row.variable) return;
 
       const newVariable: EndpointVariableData = {
         id: row.endpointVariableId ?? row.id,
@@ -327,6 +334,7 @@ const RequestVariables: React.FC<RequestVariablesProps> = ({
         value: row.value,
         description: row.description,
         operator: requestTab.tab === EndpointTab.Params ? (row.operator as RequestOperator) || '=' : undefined,
+        paramType: row.paramType,
       };
       variables.push(newVariable);
     });

--- a/GUI/src/components/Flow/EdgeTypes/AddEndpointModal.tsx
+++ b/GUI/src/components/Flow/EdgeTypes/AddEndpointModal.tsx
@@ -124,6 +124,15 @@ const AddEndpointModal: React.FC<AddEndpointModalProps> = ({
       setIsSaving(false);
       return;
     }
+    // Block save if any PATH parameter has no value
+    const missingPathParam = allParams.find((p) => p.paramType === 'path' && !p.value?.trim());
+    if (missingPathParam) {
+      useToastStore
+        .getState()
+        .error({ title: t('newService.endpoint.missingPathParam', { name: missingPathParam.name }) });
+      setIsSaving(false);
+      return;
+    }
 
     // Resolve serviceId: service-flow gets it from the store; registry preserves the
     // endpoint's own serviceId (edit) or uses empty string (create).

--- a/GUI/src/components/Flow/EdgeTypes/ApiElementsPanel.tsx
+++ b/GUI/src/components/Flow/EdgeTypes/ApiElementsPanel.tsx
@@ -4,8 +4,6 @@ import AddEndpointModal from 'components/Flow/EdgeTypes/AddEndpointModal';
 import { EndpointTooltipContent } from 'pages/ApiRegistryPage/ApiRegistryTable';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
-import './ApiElementsPanel.scss';
 import {
   MdArrowDownward,
   MdArrowUpward,
@@ -21,6 +19,8 @@ import {
   MdOutlineWest,
   MdUnfoldMore,
 } from 'react-icons/md';
+import { useParams } from 'react-router-dom';
+import './ApiElementsPanel.scss';
 import useApiRegistryStore from 'store/api-registry.store';
 import useToastStore from 'store/toasts.store';
 import { Step, StepType } from 'types';

--- a/GUI/src/i18n/en/common.json
+++ b/GUI/src/i18n/en/common.json
@@ -285,6 +285,8 @@
       "mandatoryNo": "No",
       "mandatoryNameValueRequired": "Name and value are mandatory",
       "nameTypeDescriptionRequired": "Name, type and description are required for all parameters",
+      "missingPathParam": "Missing value for '{{name}}'",
+      "unresolvedPlaceholder": "Unresolved placeholder '{{name}}'",
       "paramTypeTooltip": "Type defines what data a parameter accepts.\n\nSTRING (default) – text (e.g. \"Tallinn\", \"ABC123\")\nNUMBER – numbers (e.g. 10, 10.5)\nBOOLEAN – true or false\nDATE – date or datetime (e.g. 2025-01-01, ISO 8601)",
       "response": "Response",
       "testUrlFirst": "Execute Test URL before saving",

--- a/GUI/src/i18n/et/common.json
+++ b/GUI/src/i18n/et/common.json
@@ -285,6 +285,8 @@
       "mandatoryNo": "Ei",
       "mandatoryNameValueRequired": "Nimi ja väärtus on kohustuslikud",
       "nameTypeDescriptionRequired": "Nimi, tüüp ja kirjeldus on kõigi parameetrite jaoks kohustuslikud",
+      "missingPathParam": "Puudub väärtus parameetrile '{{name}}'",
+      "unresolvedPlaceholder": "Lahendamata kohatäitja '{{name}}'",
       "paramTypeTooltip": "Tüüp määrab, millist andmetüüpi parameeter aktsepteerib.\n\nSTRING (vaikimisi) – tekst (nt \"Tallinn\", \"ABC123\")\nNUMBER – arvud (nt 10, 10.5)\nBOOLEAN – true või false\nDATE – kuupäev või kuupäev-kellaaeg (nt 2025-01-01, ISO 8601)",
       "response": "Vastus",
       "testUrlFirst": "Enne salvestamist käivita Testi URLi",

--- a/GUI/src/pages/ApiRegistryPage/ApiRegistryTable.tsx
+++ b/GUI/src/pages/ApiRegistryPage/ApiRegistryTable.tsx
@@ -375,7 +375,7 @@ const ApiRegistryTable: React.FC<ApiRegistryTableProps> = ({
               <li key={i} className={i === pagination.pageIndex ? 'active' : ''}>
                 <button
                   type="button"
-                  style={{ cursor: 'pointer', background: 'none', border: 'none', padding: 0 }}
+                  style={{ cursor: 'pointer', border: 'none', padding: 0 }}
                   onClick={() => setPagination({ ...pagination, pageIndex: i })}
                 >
                   {i + 1}

--- a/GUI/src/store/api-registry.store.ts
+++ b/GUI/src/store/api-registry.store.ts
@@ -129,7 +129,7 @@ const useApiRegistryStore = create<ApiRegistryState>((set, get) => ({
       }
     }
     // Skip test if any path variable placeholder is still unresolved
-    if (/(?<!\$)\{([^}]+)\}/.test(url)) return;
+    if (/(?<!\$)\{(\w+)\}/.test(url)) return;
 
     // Strip any inline query string — query params are sent separately
     const urlBase = url.includes('?') ? url.split('?')[0] : url;

--- a/GUI/src/store/api-registry.store.ts
+++ b/GUI/src/store/api-registry.store.ts
@@ -116,18 +116,34 @@ const useApiRegistryStore = create<ApiRegistryState>((set, get) => ({
     const def = endpoint.definitions?.[0];
     if (!def) return;
 
-    const url = def.url || def.openApiUrl || def.path || '';
+    let url = def.url || def.openApiUrl || def.path || '';
     if (!url) return;
+
+    // Resolve {paramName} path variable placeholders using stored param values
+    const allParams = def.params?.variables ?? [];
+    const pathParams = allParams.filter((p) => p.paramType === 'path');
+    const queryParams = allParams.filter((p) => p.paramType !== 'path');
+    for (const param of pathParams) {
+      if (param.value?.trim()) {
+        url = url.split(`{${param.name}}`).join(encodeURIComponent(param.value));
+      }
+    }
+    // Skip test if any path variable placeholder is still unresolved
+    if (/(?<!\$)\{([^}]+)\}/.test(url)) return;
+
+    // Strip any inline query string — query params are sent separately
+    const urlBase = url.includes('?') ? url.split('?')[0] : url;
+    const queryOnlyParams = def.params ? { ...def.params, variables: queryParams } : undefined;
 
     let networkError = false;
     try {
       await api.post(testEndpointUrl(), {
         endpointId: endpoint.endpointId,
         request: {
-          url,
+          url: urlBase,
           method: def.methodType ?? 'GET',
           headers: extractMapValues(def.headers),
-          params: extractMapValues(def.params),
+          params: extractMapValues(queryOnlyParams),
           body: getEndpointBody(def),
         },
       });

--- a/GUI/src/types/endpoint/endpoint-variable-data.ts
+++ b/GUI/src/types/endpoint/endpoint-variable-data.ts
@@ -17,4 +17,6 @@ export type EndpointVariableData = {
   default?: string;
   value?: string;
   testValue?: string;
+  /** 'path' for URL path placeholders like {id}; 'query' for query-string params */
+  paramType?: 'path' | 'query';
 };

--- a/GUI/src/types/request-variables/request-variables-row-data.ts
+++ b/GUI/src/types/request-variables/request-variables-row-data.ts
@@ -13,4 +13,5 @@ export type RequestVariablesRowData = {
   type?: string;
   value?: string;
   variable?: string;
+  paramType?: 'path' | 'query';
 };

--- a/GUI/src/types/request-variables/request-variables-table-columns.ts
+++ b/GUI/src/types/request-variables/request-variables-table-columns.ts
@@ -13,4 +13,5 @@ export type RequestVariablesTableColumns = {
   value?: string;
   variable?: string;
   operator?: RequestOperator;
+  paramType?: 'path' | 'query';
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ruuter
     environment:
       - application.cors.allowedOrigins=http://localhost:3006,http://localhost:3001,http://localhost:8086
-      - application.httpCodesAllowList=200,201,202,204,400,401,403,500
+      - application.httpCodesAllowList=200,201,202,204,301,302,400,401,403,500
       - application.logging.displayRequestContent=true
       - application.logging.displayResponseContent=true
       - server.port=8086


### PR DESCRIPTION
#981 

### Overview
Adds full support for path variable placeholders (e.g. `{param}`) in custom API endpoint URLs across the service flow canvas, API Registry, and the endpoint test/save flow. Previously, URLs containing `{name}` placeholders were sent raw to the backend, causing Spring's `RestTemplate` to throw `Not enough variable values available to expand 'param'`.

### Changes

#### Types
- Added `paramType?: 'path' | 'query'` to `EndpointVariableData`, `RequestVariablesRowData`, and `RequestVariablesTableColumns` to distinguish path variable placeholders from query string parameters throughout the data model

#### URL Parsing (`Custom/index.tsx`)
- Replaced `parseURL()` with `parseURLWithPlaceholders()` which scans the URL **path** for `{name}` placeholders in addition to parsing the query string
- Path placeholders are registered as `paramType: 'path'` params; query params get `paramType: 'query'`
- Fixed URL rebuild in `onParametersChange` to use string split instead of `new URL()` (which crashes on `{braces}`) — preserves the path template including placeholders
- When a query param value is empty, the placeholder `{paramName}` is restored in the URL keeping it as a live template
- When a path param is renamed in the params table, the `{oldName}` placeholder in the URL path is automatically replaced with `{newName}` and the input field is updated via ref

#### Test URL (`Custom/index.tsx` — `handleJsonRequestClick`)
- Path param names are derived directly from `{name}` placeholders in the URL path string (not from stored `paramType`) so that endpoints loaded from the DB work correctly even if `paramType` was not persisted
- Validates all path params have values before testing — shows `"Missing value for '{{name}}'"` toast on failure
- Validates all named query params have values
- Substitutes path param values into the URL with `encodeURIComponent` before sending
- Strips the query string from the URL — query params are sent separately as a map
- Guards against any remaining unresolved `{name}` — shows `"Unresolved placeholder '{{name}}'"` toast and aborts

#### API Registry Quick Test (`api-registry.store.ts`)
- Same path variable resolution logic applied to the quick test button in the registry table
- Separates path params from query params before posting to `test-endpoint.yml`
- Silently skips the test if any placeholder is still unresolved (no stored value)

#### Save Guard (`AddEndpointModal.tsx`)
- Blocks saving if any path parameter has an empty value, preventing a broken URL template from being persisted to the DB

#### Params Table (`RequestVariables/index.tsx`)
- `paramType` is now propagated through every row construct/update/operator operation so it is never lost during edits
- Path param rows are always kept in the variable list even when their value is empty, so the user can fill them in
- All custom params (including path params) have editable names — renaming a path param syncs back to the URL

#### Variable Cell (`VariableCell/index.tsx`)
- Non-editable variable name cells (e.g. nested OpenAPI schema fields) now render as a read-only `FormInput` with a grey background instead of a plain `<p>` tag, maintaining visual consistency with the rest of the table

#### i18n
- Added `missingPathParam` and `unresolvedPlaceholder` translation keys in both English and Estonian


### How it works (example)

1. User types `https://api.example.com/{param}/data` in the URL field
2. `{param}` is detected as a path placeholder → a `paramType: 'path'` row appears in the Params table
3. User enters a value (e.g. `admin`) for `param`
4. On **Test URL** → URL becomes `https://api.example.com/admin/data`, sent to the backend with no unresolved placeholders
5. On **Save** → blocked if `param` has no value; proceeds otherwise
6. If user renames `param` → `paramId` in the table → URL updates to `https://api.example.com/{paramId}/data` automatically